### PR TITLE
ci: strengthen validation and dependency checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:00"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+    groups:
+      deepseek-harness:
+        patterns:
+          - "@deepseek-ai/*"
+      pi-ai:
+        patterns:
+          - "@earendil-works/*"
+      npm-development:
+        dependency-type: development
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@deepseek-ai/*"
+          - "@earendil-works/*"
+      npm-production:
+        dependency-type: production
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@deepseek-ai/*"
+          - "@earendil-works/*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:30"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 2
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,14 @@ name: CI
 
 on:
   push:
-    branches: ['**']
+    branches: [main]
   pull_request:
+    branches: [main]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -16,14 +21,19 @@ jobs:
       matrix:
         node-version: ['22.19.0', '24.x']
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10.30.3
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
       - run: pnpm --config.minimum-release-age=0 install --frozen-lockfile
       - name: Lint package and source hygiene
         run: pnpm run lint
@@ -37,6 +47,14 @@ jobs:
         run: pnpm run pack:check
       - name: Validate isolated DSH installation
         run: pnpm --silent run check:dsh-install
+      - name: Verify committed build output
+        shell: bash
+        run: |
+          changes="$(git status --porcelain --untracked-files=all -- lib)"
+          if [[ -n "$changes" ]]; then
+            printf '%s\n' "$changes"
+            exit 1
+          fi
 
   # Alpha CI deliberately has no npm-publish job. Publishing requires a later,
   # separately authorized release workflow.

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,24 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: dependency-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high


### PR DESCRIPTION
## What changed

- run push CI only on `main`, cancel superseded branch runs, and cap job duration
- upgrade and pin GitHub Actions to immutable commit SHAs
- cache the pnpm store and fail when committed `lib/**` differs from a clean build
- reject pull requests that introduce high or critical dependency vulnerabilities
- group weekly npm, DeepSeek Harness, pi-ai, and GitHub Actions updates with bounded PR counts

## Why

The existing validation suite is comprehensive, but feature branches run duplicate push and pull-request matrices, committed build output can drift without failing CI, and dependency updates have no continuous review path.

## Validation

- `pnpm run check` — exit 0; 14 test files and 74 tests passed; build and pack validation passed
- `pnpm --silent run check:dsh-install` — exit 0; DSH `0.1.0-rc.6`, defaults unchanged, optional capabilities disabled
- Ruby YAML parsing for all three changed files — exit 0
- `git diff --cached --check` — exit 0
- clean `lib/**` status after both build paths

## Out of scope

- no package version or product-source changes
- no npm publication or release automation
- no repository ruleset or Dependabot settings mutation before this workflow lands and its check names are proven
