### PR TITLE
ci: keep major Dependabot updates separate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,25 +11,41 @@ updates:
     open-pull-requests-limit: 5
     groups:
       deepseek-harness:
+        applies-to: version-updates
         patterns:
           - "@deepseek-ai/*"
+        update-types:
+          - minor
+          - patch
       pi-ai:
+        applies-to: version-updates
         patterns:
           - "@earendil-works/*"
+        update-types:
+          - minor
+          - patch
       npm-development:
+        applies-to: version-updates
         dependency-type: development
         patterns:
           - "*"
         exclude-patterns:
           - "@deepseek-ai/*"
           - "@earendil-works/*"
+        update-types:
+          - minor
+          - patch
       npm-production:
+        applies-to: version-updates
         dependency-type: production
         patterns:
           - "*"
         exclude-patterns:
           - "@deepseek-ai/*"
           - "@earendil-works/*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directory: /
@@ -41,5 +57,9 @@ updates:
     open-pull-requests-limit: 2
     groups:
       github-actions:
+        applies-to: version-updates
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Problem

The initial Dependabot scan grouped seven unrelated major development upgrades into PR #8. A green aggregate check does not make React, TypeScript, jsdom, and Node type major upgrades one reviewable unit.

## Root cause

All existing dependency groups accepted every SemVer update type, so Dependabot combined major upgrades with routine maintenance.

## Changes

- scope all five existing groups explicitly to version updates
- group only minor and patch updates
- leave major updates unmatched so Dependabot opens one PR per dependency
- preserve the existing DeepSeek Harness, pi-ai, development, production, and GitHub Actions boundaries

## Verification

- `ruby -e ...` policy assertion — exit 0; five groups, grouped types limited to minor/patch, majors remain individual
- `pnpm run check` — exit 0; lint, typecheck, 15 test files / 93 tests, build, and pack check passed
- `git diff --cached --check` — exit 0

## Out of scope

- no automatic merge
- no changes to product code, package versions, or release state
- no merge, close, or rewrite of Dependabot PR #7 or #8
