### PR TITLE
docs: add security and maintainer baseline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,89 @@
+name: Bug report
+description: Report a reproducible problem with Codex Connect
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Never include an OAuth URL, authorization code, access or refresh token, account ID, credential-file contents, or other secrets.** Use the private security advisory link in the repository for suspected vulnerabilities.
+  - type: input
+    id: plugin_version
+    attributes:
+      label: Codex Connect version
+      description: Give the installed plugin version only.
+      placeholder: 0.1.0-alpha.x
+    validations:
+      required: true
+  - type: input
+    id: dsh_version
+    attributes:
+      label: DeepSeek Harness version
+      description: Paste the version from `dsh --version`; remove unrelated output.
+      placeholder: 0.1.0-rc.x
+    validations:
+      required: true
+  - type: input
+    id: node_version
+    attributes:
+      label: Node.js version
+      description: Paste the version from `node --version`.
+      placeholder: v22.19.0
+    validations:
+      required: true
+  - type: dropdown
+    id: operating_system
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Other (describe below)
+    validations:
+      required: true
+  - type: input
+    id: profile
+    attributes:
+      label: DeepSeek Harness profile
+      description: Give the profile name only; do not include a home directory or local path.
+      placeholder: web
+    validations:
+      required: true
+  - type: textarea
+    id: minimal_reproduction
+    attributes:
+      label: Minimal reproduction
+      description: List the smallest commands and UI steps that reproduce the problem. Redact secrets and local paths.
+      placeholder: |
+        1. Install or configure ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Secret-free diagnostics
+      description: Paste redacted output from both `doctor --json` and `status --json`. Do not paste credential contents, OAuth data, account IDs, or private paths.
+      render: shell
+    validations:
+      required: true
+  - type: checkboxes
+    id: safe_report
+    attributes:
+      label: Safety confirmation
+      options:
+        - label: I removed OAuth URLs, authorization codes, tokens, account IDs, credential-file contents, and other secrets from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability privately
+    url: https://github.com/franksong2702/dsh-codex-connect/security/advisories/new
+    about: Use a GitHub Private Security Advisory. Never disclose OAuth URLs, codes, tokens, account IDs, or credential-file contents publicly.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,46 @@
+name: Feature request
+description: Suggest a focused improvement to Codex Connect
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Keep proposals focused. Do not include OAuth URLs, codes, tokens, account IDs, credential-file contents, or other secrets.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What user problem should this address?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Proposed scope
+      description: Describe the smallest user-visible change and the profiles or commands it affects.
+    validations:
+      required: true
+  - type: dropdown
+    id: default_off
+    attributes:
+      label: Default-off behavior
+      description: State whether the feature is disabled unless a user explicitly opts in.
+      options:
+        - Yes — disabled by default
+        - No — changes an existing default (explain in scope)
+    validations:
+      required: true
+  - type: textarea
+    id: security_impact
+    attributes:
+      label: Security and privacy impact
+      description: Explain new permissions, network access, data handling, trust boundaries, and how users can disable it.
+    validations:
+      required: true
+  - type: checkboxes
+    id: safe_report
+    attributes:
+      label: Safety confirmation
+      options:
+        - label: I have not included OAuth URLs, authorization codes, tokens, account IDs, credential-file contents, or other secrets.
+          required: true

--- a/.github/ISSUE_TEMPLATE/install-problem.yml
+++ b/.github/ISSUE_TEMPLATE/install-problem.yml
@@ -1,0 +1,104 @@
+name: Installation problem
+description: Report a reproducible Codex Connect installation problem
+title: "[Install]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Never include an OAuth URL, authorization code, access or refresh token, account ID, credential-file contents, or other secrets.** Use the private security advisory link in the repository for suspected vulnerabilities.
+  - type: input
+    id: plugin_version
+    attributes:
+      label: Codex Connect version
+      description: Give the package version you tried to install.
+      placeholder: 0.1.0-alpha.x
+    validations:
+      required: true
+  - type: input
+    id: dsh_version
+    attributes:
+      label: DeepSeek Harness version
+      description: Paste the version from `dsh --version`; remove unrelated output.
+      placeholder: 0.1.0-rc.x
+    validations:
+      required: true
+  - type: input
+    id: node_version
+    attributes:
+      label: Node.js version
+      description: Paste the version from `node --version`.
+      placeholder: v22.19.0
+    validations:
+      required: true
+  - type: dropdown
+    id: operating_system
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Other (describe below)
+    validations:
+      required: true
+  - type: input
+    id: profile
+    attributes:
+      label: DeepSeek Harness profile
+      description: Give the profile name only; do not include a home directory or local path.
+      placeholder: web
+    validations:
+      required: true
+  - type: textarea
+    id: install_command
+    attributes:
+      label: Installation command
+      description: Paste the exact command used, after removing secrets and private paths.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: minimal_reproduction
+    attributes:
+      label: Minimal reproduction
+      description: List the smallest clean-checkout steps that reproduce the installation problem. Redact secrets and local paths.
+      placeholder: |
+        1. Run ...
+        2. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: sanitized_error
+    attributes:
+      label: Sanitized error output
+      description: Paste the error after removing OAuth data, tokens, account IDs, credential contents, and private paths.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Secret-free diagnostics
+      description: Paste redacted output from both `doctor --json` and `status --json`. Do not paste credential contents, OAuth data, account IDs, or private paths.
+      render: shell
+    validations:
+      required: true
+  - type: checkboxes
+    id: safe_report
+    attributes:
+      label: Safety confirmation
+      options:
+        - label: I removed OAuth URLs, authorization codes, tokens, account IDs, credential-file contents, and other secrets from this report.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,55 @@
+## Problem
+
+What user or maintenance problem does this pull request solve?
+
+## Scope
+
+What files and behavior are changed? What is deliberately not changed?
+
+## Validation
+
+Provide the validation triplet below. Do not write only “tests pass”.
+
+Validation command:
+
+```text
+<exact command, for example: pnpm run check>
+```
+
+Result:
+
+```text
+<exit code and important output lines>
+```
+
+Evidence path:
+
+```text
+<log, report, screenshot, or other concrete artifact path>
+```
+
+## Security
+
+Describe security-sensitive behavior, permissions, network access, trust-boundary
+changes, and why the change is safe. State “None” when there is no impact.
+
+## Privacy
+
+Describe data read, written, transmitted, or persisted by this change. Confirm
+that OAuth URLs, codes, tokens, account IDs, credential contents, and private
+machine paths are not included in source, tests, logs, screenshots, or docs.
+
+## Out of scope
+
+List related work intentionally left for a separate change.
+
+## Checklist
+
+- [ ] This pull request contains one focused change and was created from `main`.
+- [ ] I ran `pnpm install --frozen-lockfile`.
+- [ ] I ran `pnpm run check`.
+- [ ] I ran any additional relevant checks and recorded the validation triplet above.
+- [ ] I ran `pnpm run build` when generated `lib/` output needed updating; I did not hand-edit generated files.
+- [ ] If the README changed, `README.md` and `docs/README.zh.md` remain synchronized.
+- [ ] Public-facing text is in English and uses the issue templates where applicable.
+- [ ] No credentials, OAuth material, account IDs, or private local paths are committed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+Thanks for helping improve Codex Connect. Keep each pull request focused on
+one change and start your branch from the current `main` branch.
+
+## Local checks
+
+From a clean checkout, install the locked dependencies and run the complete
+check before opening a pull request:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm run check
+```
+
+The `lib/` directory is generated output. Update it only by running the project
+build (`pnpm run build`); do not hand-edit generated files.
+
+## Documentation and issue reports
+
+- Keep `README.md` and `docs/README.zh.md` in sync when changing the user guide.
+  Preserve the same commands, behavior, and safety warnings in both languages;
+  keep canonical model, provider, and command identifiers unchanged.
+- Public-facing project copy, issue titles, and template text must be in English.
+  Chinese documentation belongs in `docs/README.zh.md`.
+- Use the supplied issue templates for bug reports, installation problems, and
+  feature requests. Do not include credentials, OAuth material, or private
+  machine paths in issues, pull requests, logs, screenshots, or test fixtures.
+- For suspected vulnerabilities, use the private security advisory link in
+  `SECURITY.md` instead of a public issue.
+
+## Pull requests
+
+Describe the problem, scope, validation command and result, evidence path, and
+any security or privacy impact. State what is deliberately out of scope. Keep
+generated changes and unrelated formatting out of a focused pull request.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,59 @@
+# Security Policy
+
+## Support policy
+
+Codex Connect is a community-maintained Alpha plugin. The supported security
+baseline is the latest published `alpha` release on the currently supported
+DeepSeek Harness and Node.js combinations documented in the README. Older Alpha
+releases may not receive fixes; please reproduce on the latest Alpha before
+reporting a problem.
+
+Security support is best effort. This project does not promise a fixed
+response, remediation, or disclosure time.
+
+## Report a vulnerability privately
+
+Use a GitHub Private Security Advisory for a suspected vulnerability:
+
+<https://github.com/franksong2702/dsh-codex-connect/security/advisories/new>
+
+Do not open a public issue or paste sensitive details into a pull request. Never
+include an OAuth authorization URL, authorization code, access or refresh token,
+account ID, credential-file contents, or any equivalent secret in a report,
+log, screenshot, or configuration snippet. Share only the minimum redacted
+steps and metadata needed to reproduce the problem.
+
+For routine bugs and installation problems, use the public issue templates and
+provide only the secret-free output requested there.
+
+## Security boundary
+
+- **Community Alpha:** This is community software in Alpha. Review changes and
+  use it only in an environment where you accept that maturity and compatibility
+  may change.
+- **Host permissions:** The plugin runs inside the active DeepSeek Harness
+  profile and inherits the host permissions that Harness grants to its shell,
+  filesystem, tools, skills, MCP integrations, and subagents. It is not an
+  additional sandbox.
+- **Local credentials:** OAuth state is kept in the DSH home on the local host.
+  The credential directory and file use owner-only permissions where supported.
+  Do not copy that state or disclose its contents.
+- **Browser origin:** Browser OAuth routes use same-origin and loopback checks by
+  default. A trusted origin is an explicit opt-in for a network you control;
+  never expose the route to the public Internet.
+- **No implicit routing:** Installing or enabling the plugin does not switch the
+  Harness default model or global search provider. Any default-model or search
+  route change must be an explicit, separate Harness configuration change.
+
+## Safe diagnostic data
+
+The following commands are designed to emit secret-free metadata. Redact any
+unexpected values before sharing their output:
+
+```sh
+dsh plugin --profile <profile> exec dsh-codex-connect doctor --json
+dsh plugin --profile <profile> exec dsh-codex-connect status --json
+```
+
+If a report contains sensitive data, remove it from the public channel and use
+the private advisory above. Do not attach the original file or log.


### PR DESCRIPTION
## Problem\n\nCodex Connect handles OAuth state but the repository does not provide a private vulnerability-reporting policy, focused issue forms, or a contribution and pull-request contract.\n\n## Scope\n\n- add SECURITY.md with the supported Alpha policy, private advisory route, sensitive-data rules, and trust boundaries\n- add focused bug, installation, and feature-request forms\n- add a pull-request template with the required validation triplet\n- add concise contribution guidance\n\nRepository settings for private vulnerability reporting and CodeQL were enabled separately and are not represented as code changes in this PR.\n\n## Validation\n\nValidation command: pnpm run check\n\nResult: exit 0; 15/15 test files and 93/93 tests passed; build completed; pack check validated 34 files.\n\nAdditional validation: Ruby YAML parse exit 0; issue-form contract check PASS; git diff --check produced no output.\n\nEvidence path: GitHub Actions checks on this pull request and the seven files in this diff.\n\n## Security and privacy\n\nThe templates direct vulnerability reports to GitHub Private Security Advisories and prohibit public disclosure of OAuth URLs, authorization codes, tokens, account IDs, credential-file contents, and private local paths. No credential or runtime behavior changes are included.\n\n## Out of scope\n\n- runtime compatibility changes\n- package version or release changes\n- npm publishing workflow\n- product feature changes