### PR TITLE
ci: add trusted publishing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,168 @@
+name: Publish alpha release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact package version to publish (for example 0.1.0-alpha.4.8)
+        required: true
+        type: string
+      confirm:
+        description: Type PUBLISH to authorize this alpha release
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: npm-release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: npm-release
+    steps:
+      - name: Check out the selected main commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 10.30.3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Pin npm for Trusted Publishing
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --global npm@11.6.4 --no-fund --no-audit
+          test "$(npm --version)" = "11.6.4"
+          test "$(node --version)" = "v24.15.0"
+          test "$(pnpm --version)" = "10.30.3"
+
+      - name: Install dependencies from the lockfile
+        run: pnpm --config.minimum-release-age=0 install --frozen-lockfile
+
+      - name: Validate release input and target availability
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          CONFIRM: ${{ inputs.confirm }}
+        run: |
+          set -euo pipefail
+          readonly PACKAGE='dsh-codex-connect'
+
+          if [[ "$CONFIRM" != 'PUBLISH' ]]; then
+            echo 'The confirmation input must be exactly PUBLISH.' >&2
+            exit 1
+          fi
+          if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-alpha\.(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*$ ]]; then
+            echo "Version must be a strict alpha semver (got: $VERSION)." >&2
+            exit 1
+          fi
+
+          package_name="$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).name")"
+          package_version="$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")"
+          if [[ "$package_name" != "$PACKAGE" || "$package_version" != "$VERSION" ]]; then
+            echo "Input $VERSION does not match $PACKAGE@$package_version." >&2
+            exit 1
+          fi
+
+          set +e
+          npm_output="$(npm view "$PACKAGE@$VERSION" version --json 2>&1)"
+          npm_status=$?
+          set -e
+          if (( npm_status == 0 )); then
+            echo "npm version $PACKAGE@$VERSION already exists." >&2
+            exit 1
+          fi
+          if [[ "$npm_output" != *E404* && "$npm_output" != *'404 Not Found'* && "$npm_output" != *'No match found'* ]]; then
+            printf '%s\n' "$npm_output" >&2
+            exit 1
+          fi
+
+          set +e
+          git ls-remote --exit-code --refs origin "refs/tags/v${VERSION}" >/dev/null 2>&1
+          tag_status=$?
+          set -e
+          if (( tag_status == 0 )); then
+            echo "Git tag v$VERSION already exists." >&2
+            exit 1
+          fi
+          if (( tag_status != 2 )); then
+            echo "Could not verify whether Git tag v$VERSION exists (git status $tag_status)." >&2
+            exit 1
+          fi
+
+          set +e
+          release_output="$(gh release view "v${VERSION}" --repo "$GITHUB_REPOSITORY" 2>&1)"
+          release_status=$?
+          set -e
+          if (( release_status == 0 )); then
+            echo "GitHub release v$VERSION already exists." >&2
+            exit 1
+          fi
+          if [[ "$release_output" != *'not found'* && "$release_output" != *'Not Found'* && "$release_output" != *404* ]]; then
+            printf '%s\n' "$release_output" >&2
+            exit 1
+          fi
+
+      - name: Run complete check before publishing
+        run: pnpm run check
+
+      - name: Publish alpha through npm Trusted Publishing
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          npm publish --tag alpha --provenance
+
+      - name: Verify npm version and alpha dist-tag
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          readonly PACKAGE='dsh-codex-connect'
+          for attempt in 1 2 3 4 5 6; do
+            version_json="$(npm view "$PACKAGE@$VERSION" version --json 2>/dev/null || true)"
+            alpha_json="$(npm view "$PACKAGE" dist-tags.alpha --json 2>/dev/null || true)"
+            if node -e '
+              const [expected, versionRaw, alphaRaw] = process.argv.slice(1)
+              const parse = (raw) => {
+                try { return JSON.parse(raw) }
+                catch { return raw.trim() }
+              }
+              if (parse(versionRaw) !== expected || parse(alphaRaw) !== expected) process.exit(1)
+            ' "$VERSION" "$version_json" "$alpha_json"; then
+              echo "npm published $PACKAGE@$VERSION with alpha=$VERSION."
+              exit 0
+            fi
+            if (( attempt < 6 )); then
+              sleep 10
+            fi
+          done
+          echo "npm did not expose $PACKAGE@$VERSION and dist-tags.alpha=$VERSION after six attempts." >&2
+          exit 1
+
+      - name: Create GitHub prerelease
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: gh release create "v${VERSION}" --repo "$GITHUB_REPOSITORY" --prerelease --target "$GITHUB_SHA" --generate-notes

--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ pnpm install --frozen-lockfile
 pnpm run check
 ```
 
+## Releases
+
+Maintainers publish alpha versions through the [manual OIDC release workflow](.github/workflows/release.yml); see the [alpha release runbook](RELEASING.md) for the separate, short-lived `latest` promotion step.
+
 ## Legal / Acknowledgements
 
 Copyright 2026 Frank Song for the modifications and additional work in Codex Connect. This project includes software derived from [Yan-Zero/dsh-codex](https://github.com/Yan-Zero/dsh-codex); Copyright 2026 Yan-Zero is retained for the upstream material. Both are distributed under Apache-2.0, with details in [NOTICE](NOTICE). This project is not affiliated with or endorsed by OpenAI, ChatGPT, Codex, DeepSeek, or DeepSeek Harness.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,11 +1,64 @@
 # Releasing an Alpha
 
-Use this checklist for a new `0.1.0-alpha.*` package release. Released versions are immutable: do not republish, overwrite, or unpublish a version to correct documentation. Publish a new version instead.
+Alpha releases are published from `main` by the manually triggered
+[OIDC release workflow](.github/workflows/release.yml). The npm package must
+already have an npm Trusted Publisher configured for this repository, workflow
+file, and the `npm-release` environment. The workflow uses no long-lived npm
+token and does not promote the `latest` dist-tag.
 
-1. Start with a clean tree and run `pnpm run check`.
-2. Update the version, both README files, `README.i18n.yaml`, and this release guidance as needed; rebuild so `lib/` carries the version.
-3. Inspect `npm pack --dry-run` and require the root `README.md`, the Chinese document under `docs/`, and no localized README beside the root README.
-4. Confirm npm 2FA is enabled, then publish with the `alpha` dist-tag (`publishConfig.tag` prevents an ordinary Alpha publish from implicitly changing `latest`).
-5. Verify the expected version, tags, and `readmeFilename` with `npm view dsh-codex-connect@alpha version dist-tags readmeFilename --json`, then perform an isolated DSH profile installation using `dsh-codex-connect@<version>`.
-6. While no stable release exists, explicitly move `latest` to the verified Alpha so the npm package page and default README do not lag: `npm dist-tag add dsh-codex-connect@<version> latest`. After the first stable release, `latest` must point only to stable releases.
-7. Create the matching GitHub prerelease and share its notes in the project Discussion and Discord. The GitHub tag remains an npm-unavailable installation fallback.
+## Before triggering the workflow
+
+1. Prepare and review the version change together: update `package.json`,
+   `README.md`, `docs/README.zh.md`, and `README.i18n.yaml` as needed. Keep the
+   English and Chinese release information synchronized; do not update only one
+   README. Update this runbook too when the release procedure changes.
+2. Before merging, run `pnpm run check` (including its build and package
+   checks), then review `npm pack --dry-run`. The packed files must include the
+   root `README.md` and Chinese document under `docs/`, with no localized README
+   beside the root README.
+3. Merge the intended package version into `main` and start with a clean tree.
+   The version must be a strict `MAJOR.MINOR.PATCH-alpha.NUMBER...` semver and
+   must exactly match `package.json`.
+4. Confirm that the matching npm version, Git tag `v<version>`, and GitHub
+   release do not already exist. Published npm versions are immutable.
+5. In the repository's **Actions** tab, run **Publish alpha release** on the
+   `main` branch. Enter the exact package version and type `PUBLISH` in the
+   confirmation field.
+
+The workflow installs with the frozen lockfile, runs `pnpm run check` before
+publishing, publishes with `npm publish --tag alpha --provenance` through npm
+Trusted Publishing, retries the npm version and `alpha` dist-tag readback, and
+creates the matching GitHub prerelease. It intentionally does not run
+`npm dist-tag add` because npm Trusted Publishing does not support that command.
+
+## Promoting `latest` (short-lived interactive authentication)
+
+When a maintainer intentionally wants the verified alpha to be the default
+install before a stable release exists, perform this promotion separately and
+interactively. Do not save or paste the OAuth URL or token into logs, issues,
+commits, or notes.
+
+```sh
+npm login --auth-type=web
+npm dist-tag add dsh-codex-connect@<version> latest
+npm view dsh-codex-connect dist-tags.latest
+npm logout
+```
+
+The readback must equal `<version>`. After the first stable release,
+`latest` must point only to stable releases.
+
+## If npm published but GitHub release creation failed
+
+Do not publish the npm version again. After confirming the npm readback, create
+the missing prerelease from the same commit with GitHub CLI:
+
+```sh
+gh release create "v<version>" --repo franksong2702/dsh-codex-connect \
+  --prerelease --target <commit-sha> --generate-notes
+```
+
+Use a short-lived `gh` authentication session as required by your local
+environment; never record its OAuth URL or token. If the target Git tag already
+exists, the command attaches the release to that tag; otherwise, stop and
+investigate the commit/tag mismatch before retrying.

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -180,6 +180,10 @@ pnpm install --frozen-lockfile
 pnpm run check
 ```
 
+## 发布
+
+维护者通过[手动 OIDC 发布 workflow](../.github/workflows/release.yml)发布 Alpha；`latest` 的独立短期提升步骤见 [Alpha 发布清单](../RELEASING.md)。
+
 ## 法律与致谢
 
 Codex Connect 的修改与新增工作 Copyright 2026 Frank Song。本项目包含派生自 [Yan-Zero/dsh-codex](https://github.com/Yan-Zero/dsh-codex) 的软件；上游内容继续保留 Copyright 2026 Yan-Zero。两部分均按 Apache-2.0 发布，详情见 [NOTICE](../NOTICE)。本项目与 OpenAI、ChatGPT、Codex、DeepSeek 或 DeepSeek Harness 不存在隶属关系，也未获得其背书。

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "check:compatibility": "node scripts/check-compatibility.mjs",
     "pack:check": "node scripts/check-pack.mjs",
     "check:dsh-install": "node scripts/check-dsh-install.mjs",
-    "check": "pnpm run lint && pnpm run typecheck && pnpm run test && pnpm run build && pnpm --silent run check:compatibility && pnpm run pack:check",
+    "check:release-workflow": "node scripts/check-release-workflow.mjs",
+    "check": "pnpm run check:release-workflow && pnpm run lint && pnpm run typecheck && pnpm run test && pnpm run build && pnpm --silent run check:compatibility && pnpm run pack:check",
     "prepublishOnly": "pnpm --config.minimum-release-age=0 run check"
   },
   "exports": {

--- a/scripts/check-release-workflow.mjs
+++ b/scripts/check-release-workflow.mjs
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const workflowPath = fileURLToPath(new URL('../.github/workflows/release.yml', import.meta.url))
+const packagePath = fileURLToPath(new URL('../package.json', import.meta.url))
+const workflow = readFileSync(workflowPath, 'utf8')
+const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'))
+
+const failures = []
+let assertionCount = 0
+
+function assertContract(name, condition) {
+  assertionCount += 1
+  if (!condition) failures.push(name)
+}
+
+assertContract('workflow is manually triggered', /^on:\s*\n\s+workflow_dispatch:/m.test(workflow))
+assertContract('version input is required', /workflow_dispatch:[\s\S]*?inputs:[\s\S]*?^\s+version:\s*\n[\s\S]*?required:\s*true/m.test(workflow))
+assertContract('explicit publish confirmation input is required', /workflow_dispatch:[\s\S]*?inputs:[\s\S]*?^\s+confirm:\s*\n[\s\S]*?required:\s*true/m.test(workflow))
+assertContract('confirmation is checked for exact PUBLISH', /if\s+\[\[\s*"\$CONFIRM"\s*!=\s*['"]PUBLISH['"]\s*\]\]/.test(workflow))
+assertContract('automatic triggers are absent', !/^\s+(?:push|pull_request|schedule):/m.test(workflow))
+assertContract('release is gated to main', /if:\s*github\.ref\s*==\s*['"]refs\/heads\/main['"]/.test(workflow))
+assertContract('npm-release environment is required', /^\s+environment:\s*npm-release\s*$/m.test(workflow))
+assertContract('release concurrency is configured', /^concurrency:\s*\n/m.test(workflow))
+
+const permissionBlock = workflow.match(/^permissions:\s*\n((?:^[ \t]+[^\n]*\n?)+)/m)?.[1] ?? ''
+const permissionNames = [...permissionBlock.matchAll(/^\s+([a-z-]+):/gm)].map((match) => match[1])
+assertContract(
+  'permissions are limited to contents write and id-token write',
+  permissionNames.length === 2 &&
+    permissionNames.includes('contents') &&
+    permissionNames.includes('id-token') &&
+    /\bcontents:\s*write\b/.test(permissionBlock) &&
+    /\bid-token:\s*write\b/.test(permissionBlock),
+)
+assertContract('long-lived npm token names are absent', !/\b(?:NPM_TOKEN|NODE_AUTH_TOKEN)\b/i.test(workflow))
+assertContract('all actions are pinned to full commit SHAs', (() => {
+  const uses = [...workflow.matchAll(/^\s+uses:\s+([^\s#]+)/gm)].map((match) => match[1])
+  return uses.length > 0 && uses.every((ref) => /@[0-9a-f]{40}$/.test(ref))
+})())
+assertContract('pnpm version is pinned', /pnpm\/action-setup@[0-9a-f]{40}[\s\S]*?version:\s*10\.30\.3/.test(workflow))
+assertContract('Node version is pinned', /node-version:\s*24\.15\.0/.test(workflow))
+assertContract('npm version is pinned', /npm\s+install\s+--global\s+npm@11\.6\.4/.test(workflow))
+assertContract('dependency installation is frozen', /pnpm(?:\s+--config\.minimum-release-age=0)?\s+install\s+--frozen-lockfile/.test(workflow))
+assertContract('workflow inputs are passed through environment variables',
+  /VERSION:\s*\$\{\{\s*inputs\.version\s*\}\}/.test(workflow) &&
+  /CONFIRM:\s*\$\{\{\s*inputs\.confirm\s*\}\}/.test(workflow))
+assertContract('strict alpha semver validation is present', /VERSION"\s*=~\s*\^\(0\|[\s\S]*-alpha\\\./.test(workflow))
+assertContract('input version is compared with package.json', /package_version[\s\S]*?VERSION/.test(workflow))
+assertContract('npm target existence is checked before publishing', /npm view "\$PACKAGE\@\$VERSION" version/.test(workflow))
+assertContract('git tag target existence is checked before publishing', /git ls-remote --exit-code --refs origin "refs\/tags\/v\$\{VERSION\}"/.test(workflow))
+assertContract('GitHub release target existence is checked before publishing', /gh release view "v\$\{VERSION\}"/.test(workflow))
+
+const publishIndex = workflow.indexOf('npm publish --tag alpha --provenance')
+const checkIndex = workflow.indexOf('pnpm run check')
+assertContract('complete check precedes npm publish', checkIndex >= 0 && publishIndex > checkIndex)
+assertContract('publish uses npm OIDC provenance and alpha tag', publishIndex >= 0)
+assertContract('post-publish version and alpha tag verification is retried',
+  /for attempt in 1 2 3 4 5 6/.test(workflow) &&
+  /npm view "\$PACKAGE\@\$VERSION" version/.test(workflow) &&
+  /npm view "\$PACKAGE" dist-tags\.alpha/.test(workflow))
+assertContract('GitHub prerelease is created from the workflow SHA',
+  /gh release create[\s\S]*?--prerelease[\s\S]*?--target "\$GITHUB_SHA"[\s\S]*?--generate-notes/.test(workflow))
+assertContract('workflow never promotes the latest dist-tag', !/npm dist-tag add/.test(workflow))
+assertContract('package check invokes this contract', packageJson.scripts?.['check:release-workflow'] === 'node scripts/check-release-workflow.mjs')
+assertContract('full check includes the release contract', /(?:^|&&)\s*pnpm run check:release-workflow(?:\s|$)/.test(packageJson.scripts?.check ?? ''))
+
+if (failures.length > 0) {
+  console.error(`release workflow contract failed (${failures.length}/${assertionCount}):`)
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log(`release workflow contract: ${assertionCount}/${assertionCount} assertions passed`)


### PR DESCRIPTION
## Summary

- add a manual, main-only npm Trusted Publishing workflow using GitHub OIDC
- require exact version and `PUBLISH` confirmation, plus npm/tag/release nonexistence checks
- run the full repository check before `npm publish --tag alpha --provenance`
- verify the npm version and alpha tag before creating the GitHub prerelease
- add a static workflow contract and document the separate short-lived `latest` promotion

## Validation

- `node scripts/check-release-workflow.mjs` — exit 0; 28/28 assertions
- `pnpm run check` — exit 0; 16 files / 100 tests; build, compatibility, and pack check (35 files)
- YAML parse — exit 0
- `git diff --check` — exit 0

## Safety

This PR does not change the package version, configure npm permissions, publish a package, move a dist-tag, or create a release. It introduces no `NPM_TOKEN` or other long-lived npm secret.