### PR TITLE
fix: authorize release preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Validate release input and target availability
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
           CONFIRM: ${{ inputs.confirm }}
         run: |

--- a/scripts/check-release-workflow.mjs
+++ b/scripts/check-release-workflow.mjs
@@ -50,6 +50,17 @@ assertContract('input version is compared with package.json', /package_version[\
 assertContract('npm target existence is checked before publishing', /npm view "\$PACKAGE\@\$VERSION" version/.test(workflow))
 assertContract('git tag target existence is checked before publishing', /git ls-remote --exit-code --refs origin "refs\/tags\/v\$\{VERSION\}"/.test(workflow))
 assertContract('GitHub release target existence is checked before publishing', /gh release view "v\$\{VERSION\}"/.test(workflow))
+const releaseValidationStep = workflow.match(
+  /^      - name: Validate release input and target availability\n([\s\S]*?)(?=^      - name:|(?![\s\S]))/m,
+)?.[1] ?? ''
+const releaseValidationEnv = releaseValidationStep.match(
+  /^        env:\n((?:^          [^\n]*\n?)+)/m,
+)?.[1] ?? ''
+assertContract(
+  'GitHub release availability check uses the workflow token',
+  /gh release view "v\$\{VERSION\}"/.test(releaseValidationStep) &&
+    /GH_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}/.test(releaseValidationEnv),
+)
 
 const publishIndex = workflow.indexOf('npm publish --tag alpha --provenance')
 const checkIndex = workflow.indexOf('pnpm run check')


### PR DESCRIPTION
## Summary

- pass the GitHub workflow token to the release target-availability preflight
- add a step-scoped static assertion so `gh release view` cannot regress to an unauthenticated call

## Failure evidence

Release run 32009535069 failed before publish with: `To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.` The full check, npm publish, dist-tag verification, and GitHub prerelease steps were all skipped. Live readback confirmed npm 4.8, tag v4.8, and GitHub release v4.8 do not exist.

## Validation

- `node scripts/check-release-workflow.mjs` — exit 0; 29/29 assertions
- `pnpm run check` — exit 0; 16 files / 100 tests; build, compatibility, and pack check (35 files)
- YAML parse — exit 0
- `git diff --check` — exit 0

No publish, tag, release, dist-tag, or npm permission change is included.