### PR TITLE
docs: show the npm alpha version in README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codex Connect
 
-[![npm version](https://img.shields.io/npm/v/dsh-codex-connect?label=npm&color=cb3837)](https://www.npmjs.com/package/dsh-codex-connect)
+[![npm version](https://img.shields.io/npm/v/dsh-codex-connect/alpha?label=npm%20alpha&color=cb3837)](https://www.npmjs.com/package/dsh-codex-connect)
 
 English | [中文](docs/README.zh.md)
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -1,6 +1,6 @@
 # Codex Connect
 
-[![npm version](https://img.shields.io/npm/v/dsh-codex-connect?label=npm&color=cb3837)](https://www.npmjs.com/package/dsh-codex-connect)
+[![npm version](https://img.shields.io/npm/v/dsh-codex-connect/alpha?label=npm%20alpha&color=cb3837)](https://www.npmjs.com/package/dsh-codex-connect)
 
 [English](../README.md) | 中文
 

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -38,7 +38,7 @@ for (const filename of productFiles) {
 
 const readme = await readFile(new URL('../README.md', import.meta.url), 'utf8')
 const fullDescription = 'Connect your ChatGPT subscription to DeepSeek Harness with OAuth, optional GPT Image generation, user-controlled defaults, Harness-native approvals, diagnostics, and reliable session recovery.'
-if (!readme.startsWith(`# Codex Connect\n\n[![npm version](https://img.shields.io/npm/v/dsh-codex-connect?label=npm&color=cb3837)](https://www.npmjs.com/package/dsh-codex-connect)\n\nEnglish | [中文](docs/README.zh.md)\n\n${fullDescription}\n`)) {
+if (!readme.startsWith(`# Codex Connect\n\n[![npm version](https://img.shields.io/npm/v/dsh-codex-connect/alpha?label=npm%20alpha&color=cb3837)](https://www.npmjs.com/package/dsh-codex-connect)\n\nEnglish | [中文](docs/README.zh.md)\n\n${fullDescription}\n`)) {
   failures.push('README opening description mismatch')
 }
 if (!readme.includes('dsh plugin --profile web add dsh-codex-connect@alpha')) failures.push('README must prefer the npm alpha install command')


### PR DESCRIPTION
## Problem

The README badge followed npm's default `latest` dist-tag, so it displayed Alpha 4.8 even when the published prerelease was Alpha 4.12.

## Root cause

The Shields endpoint did not select the npm `alpha` dist-tag.

## Scope

- Point the English and Chinese README badges at the `alpha` dist-tag.
- Label the badge `npm alpha` so it does not imply that `latest` was promoted.
- Update the README lint contract to match the synchronized badge.

## Validation

- `pnpm run check` — exit 0; 27 test files and 175 tests passed; compatibility and pack checks passed.
- `git diff --check` — exit 0.
- The Shields endpoint returned `0.1.0-alpha.4.12`.

## Security and privacy

No security or privacy behavior changes.

## Out of scope

This PR does not change package versions or npm dist-tags, and does not promote `latest`.
