### PR TITLE
fix: align Codex Connect card with native surface

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1861,8 +1861,7 @@ window.__ModuleLoader__.load({
 		const cardStyle = {
 			overflow: "hidden",
 			border: "1px solid var(--dsw-alias-border-l2)",
-			borderRadius: 10,
-			background: "var(--dsw-alias-bg-module-platform)"
+			borderRadius: 10
 		};
 		const headerStyle = {
 			boxSizing: "border-box",
@@ -1931,7 +1930,10 @@ window.__ModuleLoader__.load({
 			const [open, setOpen] = (0, react.useState)(false);
 			const title = t("title");
 			return /* @__PURE__ */ (0, react_jsx_runtime.jsxs)("li", {
-				style: cardStyle,
+				style: {
+					...cardStyle,
+					background: `var(--dsw-alias-bg-layer-${open ? "2" : "3"})`
+				},
 				children: [/* @__PURE__ */ (0, react_jsx_runtime.jsxs)("button", {
 					type: "button",
 					style: headerStyle,

--- a/src/client/OpenAICodexPluginCard.tsx
+++ b/src/client/OpenAICodexPluginCard.tsx
@@ -19,7 +19,6 @@ const cardStyle: CSSProperties = {
   overflow: 'hidden',
   border: '1px solid var(--dsw-alias-border-l2)',
   borderRadius: 10,
-  background: 'var(--dsw-alias-bg-module-platform)',
 }
 const headerStyle: CSSProperties = {
   boxSizing: 'border-box',
@@ -62,7 +61,7 @@ export function OpenAICodexPluginCard({ t, configScope, updater }: OpenAICodexPl
   const [open, setOpen] = useState(false)
   const title = t('title')
   return (
-    <li style={cardStyle}>
+    <li style={{ ...cardStyle, background: `var(--dsw-alias-bg-layer-${open ? '2' : '3'})` }}>
       <button
         type="button"
         style={headerStyle}

--- a/tests/client-registration.spec.ts
+++ b/tests/client-registration.spec.ts
@@ -55,7 +55,7 @@ describe('OpenAI Codex browser contribution', () => {
       readFile(new URL('../src/client/locales.ts', import.meta.url), 'utf8'),
       readFile(new URL('../src/adapter.ts', import.meta.url), 'utf8'),
     ])
-    expect(clientCard).toContain('<li style={cardStyle}>')
+    expect(clientCard).toContain('<li style={{ ...cardStyle, background:')
     expect(clientCard).toContain('aria-expanded={open}')
     expect(locales.match(/title: 'Codex Connect'/gu)).toHaveLength(2)
     expect(adapter).toContain("displayName: 'OpenAI Codex'")

--- a/tests/openai-codex-plugin-card.client.spec.tsx
+++ b/tests/openai-codex-plugin-card.client.spec.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { OpenAICodexPluginCard } from '../src/client/OpenAICodexPluginCard.tsx'
 import { en } from '../src/client/locales.ts'
@@ -14,7 +14,7 @@ describe('OpenAI Codex Plugin configuration card', () => {
     render(
       <OpenAICodexPluginCard
         t={(key) => en[key]}
-        configScope={{} as never}
+        configScope={undefined as never}
         useSessions={vi.fn() as never}
         useWorkspaces={vi.fn() as never}
       />,
@@ -22,6 +22,9 @@ describe('OpenAI Codex Plugin configuration card', () => {
 
     const header = screen.getByRole('button', { name: `${en.expand}: ${en.title}` })
     expect(header.textContent).toContain('GPT Image')
+    expect(header.closest('li')?.style.background).toBe('var(--dsw-alias-bg-layer-3)')
+    fireEvent.click(header)
+    expect(header.closest('li')?.style.background).toBe('var(--dsw-alias-bg-layer-2)')
     const icon = header.querySelector('svg')
 
     expect(icon?.getAttribute('viewBox')).toBe('0 0 14 14')


### PR DESCRIPTION
## Problem

The collapsed Codex Connect card used the module-platform background, so it appeared gray next to DSH's white native plugin cards. The color did not represent a disabled or selected state.

## Root cause

The plugin-owned card shell used a different theme surface token from DSH's native PluginCard.

## Scope

- Use DSH's native layer-3 surface while the card is collapsed.
- Use the native layer-2 surface while the card is expanded.
- Add a regression assertion for both disclosure states.
- Rebuild the committed browser bundle.

## Validation

Validation command: pnpm exec vitest run tests/openai-codex-plugin-card.client.spec.tsx tests/client-registration.spec.ts
Result: exit 0; 2 test files and 7 tests passed.
Evidence: tests/openai-codex-plugin-card.client.spec.tsx

Validation command: pnpm run check
Result: exit 0; 34 test files and 234 tests passed, build and compatibility checks passed, and 38 packed files were validated.
Evidence: package.json check script and generated lib/client.js

## Security and privacy

No security or privacy impact. This changes only client-side theme tokens.

## Out of scope

Daybook and other third-party plugin cards are unchanged. No spacing, radius, or disclosure behavior is changed.
