### PR TITLE
ci: verify installed model runtime in upstream canary

### DIFF
--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   git hash-object README.md docs/README.zh.md
-README.md: 23a9b8e505e29e860f0e21ef674c4c605d2dd639
-docs/README.zh.md: 1fc02c19220a6d15d39c0094922624619ce0ecb8
+README.md: 77aa0cb492eb9149b2d2237188813c8166b3939d
+docs/README.zh.md: b3afe618fa95a13375b23ee1eb849d2c9aca045a

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -3,4 +3,4 @@
 # after editing either side, bring the other along and re-record with:
 #   git hash-object README.md docs/README.zh.md
 README.md: 77aa0cb492eb9149b2d2237188813c8166b3939d
-docs/README.zh.md: b3afe618fa95a13375b23ee1eb849d2c9aca045a
+docs/README.zh.md: dc98646eaa58fea0c2733e07c08ae99cee332c80

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Selecting Codex as the profile's global search route is another explicit change:
 
 - The only verified compatibility combination is DSH plugin API packages `0.1.1-rc.2`, `@earendil-works/pi-ai` `0.82.1`, and Node.js `^22.19.0 || >=24.0.0`; see [compatibility.json](compatibility.json). Alpha 4.18 uses the rc.2 keyed Plugin configuration slot; users of older DSH API packages should upgrade to the rc.2 API packages.
 - Upgrade the DSH plugin API packages and `@earendil-works/pi-ai` as one group, then run `dsh-codex-connect doctor --json` and the compatibility check again. This contract does not make claims about future versions.
+- When the daily upstream check finds a new `latest` or `next` DSH candidate, it installs Codex Connect into an isolated profile, boots the installed model runtime without OAuth credentials, verifies model and reasoning-effort discovery, and confirms provider disposal. Live sign-in, quota, and model requests still require manual validation in the test profile.
 - ChatGPT plan eligibility, model access, quotas, and backend behavior are controlled by OpenAI and may change.
 - The Codex endpoint does not enforce the ordinary Responses `max_output_tokens` field. Harness compaction still works, but that summary cap cannot be imposed server-side on this route.
 - Shell, filesystem, skills, MCP, subagents, approvals, permissions, attachments, session persistence, compaction, and recovery continue to come from the active Harness profile.

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -241,7 +241,7 @@ dsh plugin --profile web exec dsh-codex-connect doctor --json
 
 - 当前唯一已验证的兼容组合是 DSH 插件 API packages `0.1.1-rc.2`、`@earendil-works/pi-ai` `0.82.1` 和 Node.js `^22.19.0 || >=24.0.0`；详见 [compatibility.json](../compatibility.json)。Alpha 4.18 使用 rc.2 的 keyed 插件配置 slot；旧版 DSH API packages 用户应升级到 rc.2 API packages。
 - 升级时请将 DSH 插件 API packages 与 `@earendil-works/pi-ai` 作为一组升级，再运行 `dsh-codex-connect doctor --json` 和兼容性检查。本契约不对未来版本作判断。
-- 每日上游检查发现新的 DSH `latest` 或 `next` 候选版本时，会把 Codex Connect 安装到隔离 Profile 中，在没有 OAuth 凭据的情况下启动已安装的模型运行时，验证模型与推理强度发现，并确认 provider 可被正确卸载。真实登录、额度和模型请求仍需在测试 Profile 中人工验证。
+- 每日上游检查发现新的 DSH `latest` 或 `next` 候选版本时，会把 Codex Connect 安装到隔离 Profile 中，在没有 OAuth 凭据的情况下启动已安装的模型运行时，验证模型与推理强度发现，并确认提供方可被正确卸载。真实登录、额度和模型请求仍需在测试 Profile 中人工验证。
 - ChatGPT 套餐资格、模型权限、额度和后端行为由 OpenAI 控制，可能变化。
 - Codex 端点不会强制普通 Responses 的 `max_output_tokens` 字段。Harness 压缩仍可工作，但这个摘要上限不能由服务端在该路由上强制。
 - shell、文件系统、skills、MCP、subagents、审批、权限、附件、会话持久化、压缩与恢复继续由当前 Harness profile 提供。

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -241,6 +241,7 @@ dsh plugin --profile web exec dsh-codex-connect doctor --json
 
 - 当前唯一已验证的兼容组合是 DSH 插件 API packages `0.1.1-rc.2`、`@earendil-works/pi-ai` `0.82.1` 和 Node.js `^22.19.0 || >=24.0.0`；详见 [compatibility.json](../compatibility.json)。Alpha 4.18 使用 rc.2 的 keyed 插件配置 slot；旧版 DSH API packages 用户应升级到 rc.2 API packages。
 - 升级时请将 DSH 插件 API packages 与 `@earendil-works/pi-ai` 作为一组升级，再运行 `dsh-codex-connect doctor --json` 和兼容性检查。本契约不对未来版本作判断。
+- 每日上游检查发现新的 DSH `latest` 或 `next` 候选版本时，会把 Codex Connect 安装到隔离 Profile 中，在没有 OAuth 凭据的情况下启动已安装的模型运行时，验证模型与推理强度发现，并确认 provider 可被正确卸载。真实登录、额度和模型请求仍需在测试 Profile 中人工验证。
 - ChatGPT 套餐资格、模型权限、额度和后端行为由 OpenAI 控制，可能变化。
 - Codex 端点不会强制普通 Responses 的 `max_output_tokens` 字段。Harness 压缩仍可工作，但这个摘要上限不能由服务端在该路由上强制。
 - shell、文件系统、skills、MCP、subagents、审批、权限、附件、会话持久化、压缩与恢复继续由当前 Harness profile 提供。

--- a/scripts/check-canary-workflow.mjs
+++ b/scripts/check-canary-workflow.mjs
@@ -70,6 +70,10 @@ assertContract('registry and candidate subprocesses have explicit timeouts', /RE
 assertContract('candidate subprocesses receive a scrubbed environment', /scrubCanaryEnvironment\(process\.env\)/.test(nextCheck) && /allowUndeclaredCanaryVersion[\s\S]*?scrubCanaryEnvironment\(process\.env\)/.test(installCheck))
 assertContract('credential-bearing environment names are filtered', /AUTH\|BEARER\|COOKIE\|CREDENTIAL\|JWT\|KEY\|PASS\|SECRET\|SESSION\|TOKEN/.test(canaryEnvironment))
 assertContract('undeclared candidates install the packed artifact', /allowUndeclaredCanaryVersion[\s\S]*?npm[\s\S]*?'pack'[\s\S]*?pluginSpec = `file:/.test(installCheck))
+assertContract(
+  'candidate checks boot the installed model runtime',
+  /check-installed-runtime/.test(installCheck) && /installed runtime contract/.test(installCheck),
+)
 assertContract('publishing and deployment commands are absent', !/npm publish|gh release create|\bdeploy\b|3080|3081/iu.test(workflow))
 assertContract(
   'credential-bearing secrets are not requested',

--- a/scripts/check-dsh-install.mjs
+++ b/scripts/check-dsh-install.mjs
@@ -12,6 +12,7 @@ const JSON_SCHEMA_VERSION = 1
 const DEFAULT_DSH_VERSION = '0.1.1-rc.2'
 const UNDECLARED_CANARY_MODE = '1'
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const RUNTIME_CHECK = resolve(REPO_ROOT, 'scripts/check-installed-runtime.mjs')
 const COMMAND_TIMEOUT_MS = 20 * 60 * 1000
 
 export class InfrastructureCheckError extends Error {}
@@ -233,6 +234,21 @@ async function main() {
     const doctorReport = parseOneLineJson(doctor.stdout, 'plugin doctor')
     assertDoctorJson(doctorReport, dshHome, REPO_ROOT)
 
+    const runtime = await runCommand(process.execPath, [
+      RUNTIME_CHECK,
+      join(dshHome, 'profiles', 'web', 'package.json'),
+    ], { cwd: workspace, env })
+    requireSuccess('installed runtime contract', runtime, 'compatibility')
+    const runtimeReport = parseOneLineJson(runtime.stdout, 'installed runtime contract')
+    if (runtimeReport?.['schemaVersion'] !== JSON_SCHEMA_VERSION
+      || runtimeReport?.['provider'] !== 'openai-codex'
+      || typeof runtimeReport?.['modelCount'] !== 'number'
+      || runtimeReport['modelCount'] < 1
+      || runtimeReport?.['reasoningModelCount'] !== runtimeReport['modelCount']
+      || runtimeReport?.['disposalVerified'] !== true) {
+      throw new CompatibilityCheckError('installed runtime contract returned an invalid report')
+    }
+
     process.stdout.write(`${JSON.stringify({
       schemaVersion: JSON_SCHEMA_VERSION,
       dshVersion: actualDshVersion,
@@ -244,6 +260,7 @@ async function main() {
         enableImageTool: false,
         enableImageGeneration: false,
       },
+      runtime: runtimeReport,
     })}\n`)
   } finally {
     await rm(tempRoot, { recursive: true, force: true })

--- a/scripts/check-dsh-next-contract.mjs
+++ b/scripts/check-dsh-next-contract.mjs
@@ -23,6 +23,7 @@ import {
   commandFailureClassification,
   installCheckExitCode,
 } from './check-dsh-install.mjs'
+import { validateRuntimeProjection } from './check-installed-runtime.mjs'
 
 const failures = []
 let assertionCount = 0
@@ -169,6 +170,31 @@ assertContract(
     stdout: 'fetch failed: ECONNRESET',
   }, 'compatibility') === 'infrastructure',
 )
+
+const runtimeProjection = validateRuntimeProjection(
+  [{ id: 'openai-codex', name: 'OpenAI Codex' }],
+  [{
+    provider: 'openai-codex',
+    id: 'gpt-contract-fixture',
+    name: 'GPT contract fixture',
+    reasoning: { efforts: [{ id: 'medium', name: 'Medium' }] },
+  }],
+)
+assertContract(
+  'installed runtime projection accepts a model with reasoning metadata',
+  runtimeProjection.modelCount === 1 && runtimeProjection.reasoningModelCount === 1,
+)
+assertContract('installed runtime projection rejects missing reasoning metadata', (() => {
+  try {
+    validateRuntimeProjection(
+      [{ id: 'openai-codex', name: 'OpenAI Codex' }],
+      [{ provider: 'openai-codex', id: 'gpt-contract-fixture', name: 'GPT contract fixture' }],
+    )
+    return false
+  } catch {
+    return true
+  }
+})())
 
 async function runCandidateFixture(exitCode) {
   const root = await mkdtemp(join(tmpdir(), 'dsh-next-contract-'))

--- a/scripts/check-installed-runtime.mjs
+++ b/scripts/check-installed-runtime.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+import { createRequire } from 'node:module'
+import { resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const JSON_SCHEMA_VERSION = 1
+const PROVIDER_ID = 'openai-codex'
+
+function requireNonEmptyString(value, label) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`)
+  }
+  return value
+}
+
+/** Validate the provider and resolved model data consumed by DSH selectors. */
+export function validateRuntimeProjection(providers, models) {
+  if (!Array.isArray(providers) || !providers.some(provider => provider?.id === PROVIDER_ID)) {
+    throw new Error(`runtime did not register the ${PROVIDER_ID} provider`)
+  }
+  if (!Array.isArray(models) || models.length === 0) {
+    throw new Error('runtime returned an empty Codex model catalog')
+  }
+
+  const modelIds = new Set()
+  let reasoningModelCount = 0
+  for (const model of models) {
+    if (model?.provider !== PROVIDER_ID) throw new Error('runtime returned a model for the wrong provider')
+    const modelId = requireNonEmptyString(model.id, 'model id')
+    requireNonEmptyString(model.name, `model ${modelId} name`)
+    if (modelIds.has(modelId)) throw new Error(`runtime returned duplicate model id ${modelId}`)
+    modelIds.add(modelId)
+
+    const efforts = model.reasoning?.efforts
+    if (!Array.isArray(efforts) || efforts.length === 0) {
+      throw new Error(`runtime model ${modelId} has no reasoning efforts`)
+    }
+    const effortIds = new Set()
+    for (const effort of efforts) {
+      const effortId = requireNonEmptyString(effort?.id, `model ${modelId} reasoning effort id`)
+      requireNonEmptyString(effort?.name, `model ${modelId} reasoning effort ${effortId} name`)
+      if (effortIds.has(effortId)) {
+        throw new Error(`runtime model ${modelId} returned duplicate reasoning effort ${effortId}`)
+      }
+      effortIds.add(effortId)
+    }
+    reasoningModelCount += 1
+  }
+
+  return { modelCount: models.length, reasoningModelCount }
+}
+
+async function importFromProfile(profilePackagePath, specifier) {
+  const require = createRequire(profilePackagePath)
+  return import(pathToFileURL(require.resolve(specifier)).href)
+}
+
+/** Boot the installed plugin against one isolated DSH profile and inspect its runtime registration. */
+export async function checkInstalledRuntime(profilePackagePath) {
+  const packagePath = resolve(profilePackagePath)
+  const [{ Context }, { default: LlmRuntime }, PiAiRuntime, OpenAICodex] = await Promise.all([
+    importFromProfile(packagePath, '@deepseek-ai/cordis'),
+    importFromProfile(packagePath, '@deepseek-ai/dsh-llm'),
+    importFromProfile(packagePath, '@deepseek-ai/dsh-llm-pi-ai'),
+    importFromProfile(packagePath, 'dsh-codex-connect'),
+  ])
+
+  const ctx = new Context()
+  try {
+    await ctx.plugin(LlmRuntime)
+    await ctx.plugin(PiAiRuntime, {})
+    const plugin = await ctx.plugin(OpenAICodex, {})
+    const providers = ctx.llm.listProviders()
+    const listed = await ctx.llm.listModels(PROVIDER_ID)
+    const models = await Promise.all(listed.map(model => ctx.llm.resolveModelInfo(PROVIDER_ID, model.id)))
+    const projection = validateRuntimeProjection(providers, models)
+
+    await plugin.dispose()
+    if (ctx.llm.listProviders().some(provider => provider.id === PROVIDER_ID)) {
+      throw new Error(`runtime retained the ${PROVIDER_ID} provider after plugin disposal`)
+    }
+
+    return {
+      schemaVersion: JSON_SCHEMA_VERSION,
+      provider: PROVIDER_ID,
+      ...projection,
+      disposalVerified: true,
+    }
+  } finally {
+    await ctx.fiber.dispose()
+  }
+}
+
+const isMain = process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (isMain) {
+  const profilePackagePath = process.argv[2]
+  if (profilePackagePath === undefined || process.argv.length !== 3) {
+    process.stderr.write('usage: check-installed-runtime <profile-package.json>\n')
+    process.exitCode = 1
+  } else {
+    try {
+      process.stdout.write(`${JSON.stringify(await checkInstalledRuntime(profilePackagePath))}\n`)
+    } catch (error) {
+      process.stderr.write(`check-installed-runtime: ${error instanceof Error ? error.message : String(error)}\n`)
+      process.exitCode = 1
+    }
+  }
+}


### PR DESCRIPTION
## Problem

The upstream DSH canary currently proves that Codex Connect can be installed, keeps profile defaults unchanged, and runs `doctor`. It does not activate the installed LLM adapter, so a DSH change could leave installation green while model or reasoning-effort discovery is broken at runtime.

## Change

- Boot the packed plugin from the isolated candidate profile with its installed Cordis, DSH LLM, and pi-ai packages.
- Require a non-empty `openai-codex` model catalog with valid, unique reasoning-effort metadata.
- Dispose the plugin and verify that its provider registration is removed.
- Include a bounded runtime report in the existing install-check JSON.
- Document that live OAuth, quota, and model requests still require manual test-profile validation.

## Validation

- `pnpm run check:canary-workflow` — 37/37 workflow assertions and 31/31 next-check assertions passed.
- `pnpm --silent run check:dsh-install` — DSH `0.1.1-rc.2`; 7 models, 7 reasoning projections, provider disposal verified.
- `pnpm run lint` — exit 0.
- `pnpm run typecheck` — exit 0.
- `pnpm run test` — 35 files, 240 tests passed (host rerun required because the workspace sandbox denies loopback listening).
- `pnpm run build` — exit 0.
- `pnpm run pack:check` — 38 packed files validated.
- `pnpm --silent run check:compatibility` — compatible.
- `git diff --cached --check` — exit 0.

## Out of scope

- No live OAuth login, quota request, or model request.
- No proxy, diagnostics UI, DSH Core menu, release, or compatibility-range change.
