### PR TITLE
docs: clarify exact version selection before installation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,16 +12,37 @@ Install `dsh-codex-connect` into one requested DeepSeek Harness profile without 
 
 ## Install and validate
 
-The only verified combination is DSH plugin API packages `0.1.1-rc.2`, `@earendil-works/pi-ai` `0.82.1`, and Node.js `^22.19.0 || >=24.0.0`. Alpha 4.20 uses the rc.2 keyed Plugin configuration slot; users of older DSH API packages should upgrade the DSH API packages and pi-ai together, then rerun `dsh-codex-connect doctor --json` and `pnpm --silent run check:compatibility`; the contract does not make claims about future versions.
+### Select an exact version before installation
 
-1. Check `dsh --version` or `dsh --help`. From a Harness checkout use `pnpm dsh`.
-2. Install the package:
+Check `dsh --version` before changing the requested profile. Use `dsh --help` to locate the CLI if needed; from a Harness checkout use `pnpm dsh --version`. Select an exact pair from [verified-compatibility.json](verified-compatibility.json):
+
+| Installed DSH version | Codex Connect version to pin |
+| --- | --- |
+| `0.1.0-rc.7` | `0.1.0-alpha.4.14` |
+| `0.1.1-rc.2` | `0.1.0-alpha.4.20` |
+
+If your exact DSH version is unknown or not listed, stop and verify the combination before installing. Do not blindly install `dsh-codex-connect@alpha`: `alpha` is a moving tag, not a compatibility guarantee. Do not infer support for newer DSH versions from these rows.
+
+Alpha 4.20's verified contract is DSH plugin API packages `0.1.1-rc.2`, `@earendil-works/pi-ai` `0.82.1`, and Node.js `^22.19.0 || >=24.0.0`. It uses the rc.2 keyed Plugin configuration slot. Staying on DSH `0.1.0-rc.7` means selecting Alpha 4.14, not installing Alpha 4.20 into that older API. Upgrading DSH is a separate decision: upgrade the DSH API packages and pi-ai together, then rerun `dsh-codex-connect doctor --json` and `pnpm --silent run check:compatibility` for the selected combination.
+
+These choices reflect the repository's existing verification record, not a new installation or runtime probe. This guidance does not fix upstream DSH compatibility or resolve [Issue #64](https://github.com/franksong2702/dsh-codex-connect/issues/64).
+
+### Install the selected version and validate
+
+1. Complete the version selection above. The commands below use `web`; substitute only the requested profile.
+2. Install the selected exact version. For DSH `0.1.0-rc.7`:
 
    ```sh
-   dsh plugin --profile web add dsh-codex-connect@alpha
+   dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.14
    ```
 
-   After `0.1.0-alpha.4.20` is published, pin it exactly with `dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.20`. If npm is unavailable after its matching GitHub prerelease is created, use `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.20'`.
+   For DSH `0.1.1-rc.2`, use Alpha 4.20:
+
+   ```sh
+   dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.20
+   ```
+
+   If npm is unavailable after its matching GitHub prerelease is created, use `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.20'` only for the DSH `0.1.1-rc.2` combination.
 
 3. Run `dsh --profile web --dump-config` and require exactly one `llm-openai-codex` row loading `dsh-codex-connect`.
 4. Confirm the effective `agent-default-model` and `web.searchProvider` values are unchanged from before installation.
@@ -75,6 +96,8 @@ Do not add the last two rows unless the user separately requested those routing 
 `openai-codex` can have only one adapter. If startup reports a collision, inspect the effective config and remove only the old `dsh-codex` bundle or manual `openai-codex` provider row after confirming it is the conflicting owner. Do not delete auth files or unrelated providers.
 
 ## Update and removal
+
+Before updating, repeat the exact-version selection above. Use `@alpha` only after verifying that the version it currently resolves to is compatible with the installed DSH; otherwise pin the selected version in the update command.
 
 ```sh
 dsh plugin --profile web update dsh-codex-connect@alpha

--- a/tests/install-version-guidance.spec.ts
+++ b/tests/install-version-guidance.spec.ts
@@ -1,0 +1,38 @@
+import { readFile } from 'node:fs/promises'
+import { describe, expect, it } from 'vitest'
+
+const install = await readFile(new URL('../INSTALL.md', import.meta.url), 'utf8')
+const compatibility = JSON.parse(await readFile(new URL('../verified-compatibility.json', import.meta.url), 'utf8'))
+const firstInstall = install.indexOf('dsh plugin --profile web add ')
+const preflight = install.slice(0, firstInstall)
+const shellBlocks = [...install.matchAll(/```sh\s*\n([\s\S]*?)```/gu)]
+  .flatMap(match => (match[1] ?? '').split('\n').map(line => line.trim()))
+
+describe('installation version guidance', () => {
+  it.each([
+    ['0.1.0-rc.7', '0.1.0-alpha.4.14'],
+    ['0.1.1-rc.2', '0.1.0-alpha.4.20'],
+  ])('selects the recorded DSH %s / Codex Connect %s pair before installation', (dsh, plugin) => {
+    expect(firstInstall).toBeGreaterThan(0)
+    expect(compatibility.pluginVersions).toContainEqual(expect.objectContaining({
+      version: plugin,
+      verifiedDshVersions: expect.arrayContaining([dsh]),
+    }))
+    const rows = preflight.split('\n').filter(line => line.trim().startsWith('|'))
+      .map(line => line.split('|').slice(1, -1).map(cell => cell.replaceAll('`', '').trim()))
+    expect(rows).toContainEqual([dsh, plugin])
+    expect(shellBlocks).toContain(`dsh plugin --profile web add dsh-codex-connect@${plugin}`)
+  })
+
+  it('requires version checks and warns against blind alpha installation before any add command', () => {
+    expect(preflight).toContain('dsh --version')
+    expect(preflight).toContain('verified-compatibility.json')
+    expect(preflight).toMatch(/(?:unknown|not listed|unlisted)[^.]*\b(?:verify|check)\b/iu)
+    expect(preflight).toMatch(/(?:do not|never)[^\n]*dsh-codex-connect@alpha/iu)
+    expect(shellBlocks).not.toContain('dsh plugin --profile web add dsh-codex-connect@alpha')
+  })
+
+  it('retains the exact Alpha 4.20 GitHub fallback when npm is unavailable', () => {
+    expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.20/iu)
+  })
+})


### PR DESCRIPTION
## Summary

- add an exact DSH/Codex Connect version-selection table before installation
- provide pinned install commands for the recorded rc.7 and rc.2 combinations
- warn against blindly installing the moving `@alpha` tag
- add a contract test that cross-checks the guidance with `verified-compatibility.json`

## Validation

- `pnpm exec vitest run tests/install-version-guidance.spec.ts` — 4/4 tests passed
- `pnpm run check` — 39 test files and 253 tests passed; release/canary checks, lint, typecheck, build, compatibility, and pack checks passed
- `git diff --check` — clean

## Scope

Related to #64. This is an installation-guidance guardrail; it does not claim a new installation or runtime probe, fix upstream DSH compatibility, or close #64.

The change is intentionally limited to `INSTALL.md` and `tests/install-version-guidance.spec.ts`. It does not modify runtime code, dependencies, generated `lib/` output, README files, or compatibility records.
