### PR TITLE
ci: enforce workflow contract checks in pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm --config.minimum-release-age=0 install --frozen-lockfile
+      - name: Validate release workflow contract
+        run: pnpm run check:release-workflow
+      - name: Validate canary workflow contract
+        run: pnpm run check:canary-workflow
       - name: Lint package and source hygiene
         run: pnpm run lint
       - name: Typecheck host and browser entries

--- a/scripts/check-canary-workflow.mjs
+++ b/scripts/check-canary-workflow.mjs
@@ -81,6 +81,16 @@ assertContract(
 )
 assertContract('package exposes the workflow contract check', packageJson.scripts?.['check:canary-workflow'] === 'node scripts/check-canary-workflow.mjs && node scripts/check-dsh-next-contract.mjs')
 assertContract('full check includes the canary workflow contract', /(?:^|&&)\s*pnpm run check:canary-workflow(?:\s|$)/.test(packageJson.scripts?.check ?? ''))
+// Match a dedicated, required step in validate, not a comment or another job.
+const ciValidateJob = ciWorkflow.match(/^  validate:\s*\n([\s\S]*?)(?=^  \S|(?![\s\S]))/m)?.[1] ?? ''
+const ciValidateSteps = [...ciValidateJob.matchAll(/^      - [\s\S]*?(?=^      - |(?![\s\S]))/gm)]
+assertContract(
+  'PR CI validate runs the canary workflow contract as a required step',
+  !/^    (?:if|continue-on-error):/m.test(ciValidateJob) && ciValidateSteps.some(([step]) =>
+    /^        run: pnpm run check:canary-workflow[ \t]*$/m.test(step) &&
+    !step.split('\n').some(line => /^(?:      - |        )(?:if|continue-on-error):/.test(line)),
+  ),
+)
 assertContract(
   'CI executes Windows command-script and process-tree contracts',
   /^  windows-canary-contract:\s*$[\s\S]*?runs-on:\s*windows-latest[\s\S]*?node scripts\/check-dsh-next-contract\.mjs/mu.test(ciWorkflow),

--- a/scripts/check-release-workflow.mjs
+++ b/scripts/check-release-workflow.mjs
@@ -2,8 +2,10 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
 const workflowPath = fileURLToPath(new URL('../.github/workflows/release.yml', import.meta.url))
+const ciWorkflowPath = fileURLToPath(new URL('../.github/workflows/ci.yml', import.meta.url))
 const packagePath = fileURLToPath(new URL('../package.json', import.meta.url))
 const workflow = readFileSync(workflowPath, 'utf8')
+const ciWorkflow = readFileSync(ciWorkflowPath, 'utf8')
 const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'))
 
 const failures = []
@@ -75,6 +77,17 @@ assertContract('GitHub prerelease is created from the workflow SHA',
 assertContract('workflow never promotes the latest dist-tag', !/npm dist-tag add/.test(workflow))
 assertContract('package check invokes this contract', packageJson.scripts?.['check:release-workflow'] === 'node scripts/check-release-workflow.mjs')
 assertContract('full check includes the release contract', /(?:^|&&)\s*pnpm run check:release-workflow(?:\s|$)/.test(packageJson.scripts?.check ?? ''))
+
+// Match a dedicated, required step in validate, not a comment or another job.
+const ciValidateJob = ciWorkflow.match(/^  validate:\s*\n([\s\S]*?)(?=^  \S|(?![\s\S]))/m)?.[1] ?? ''
+const ciValidateSteps = [...ciValidateJob.matchAll(/^      - [\s\S]*?(?=^      - |(?![\s\S]))/gm)]
+assertContract(
+  'PR CI validate runs the release workflow contract as a required step',
+  !/^    (?:if|continue-on-error):/m.test(ciValidateJob) && ciValidateSteps.some(([step]) =>
+    /^        run: pnpm run check:release-workflow[ \t]*$/m.test(step) &&
+    !step.split('\n').some(line => /^(?:      - |        )(?:if|continue-on-error):/.test(line)),
+  ),
+)
 
 if (failures.length > 0) {
   console.error(`release workflow contract failed (${failures.length}/${assertionCount}):`)


### PR DESCRIPTION
## Problem

The package `check` script validates the release and upstream-canary workflow contracts, but pull-request CI did not run those two checks. A workflow change could therefore pass PR CI without exercising its own contract guards.

## Change

- run the release workflow contract and upstream canary workflow contract as required steps in the PR `validate` job
- make each existing contract checker assert that its check is present as an unconditional step in that job
- preserve the existing capability CLI, browser, Windows, isolated-install, and committed-build-output checks

## Validation

- `node scripts/check-release-workflow.mjs` — 30/30 assertions passed
- `node scripts/check-canary-workflow.mjs` — 38/38 assertions passed
- `pnpm exec vitest run` — 38 test files and 249 tests passed
- `pnpm run check` — passed
- negative contract harness — 30/30 cases passed, including missing, conditional, commented, and misplaced steps
- `git diff --check` — clean

## Scope

This is an independent CI contract-parity change based on `main`. It does not include the capability diagnostics implementation from PR #67.

The change is limited to `.github/workflows/ci.yml`, `scripts/check-release-workflow.mjs`, and `scripts/check-canary-workflow.mjs`. It does not modify runtime code, dependencies, release behavior, browser or Windows job semantics, or generated output.

## Out of scope

macOS smoke coverage, real OAuth checks, headless request-exit coverage, upstream DSH changes, merging, and publishing remain separate work.
