### PR TITLE
docs: align Alpha 4.22 quick start with published package

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,7 +45,7 @@ These choices reflect the repository's existing verification record, not a new i
    dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.21
    ```
 
-   After the matching package is published, use Alpha 4.22 with DSH `0.1.2-alpha.2`:
+   For DSH `0.1.2-alpha.2`, use Alpha 4.22:
 
    ```sh
    dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.22

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   git hash-object README.md docs/README.zh.md
-README.md: a70138a6cef1b38bf564eb3d187046a2388305a1
-docs/README.zh.md: f44a46b738a80bbb13765bb27f9424890c6d8663
+README.md: 47599b77928c7dfc535c9544c357f0ee98b466e2
+docs/README.zh.md: 83998aac93878da15c4dbbe122e89b977ca44454

--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ The setup and image-result screenshots in this English guide are captured from t
 
 ## Quick start (about five minutes)
 
-This guide uses the `web` profile. Replace `web` with the name of the Harness profile you already use. You need a working `dsh` installation; from a DeepSeek Harness source checkout, prefix the commands with `pnpm`.
+This quick start targets DSH `0.1.2-alpha.2` with Codex Connect Alpha 4.22. Check `dsh --version` first. For DSH `0.1.1-rc.2` or `0.1.0-rc.7`, select the matching plugin version in [INSTALL.md](INSTALL.md). This guide uses the `web` profile; replace `web` with the name of the Harness profile you already use. From a DeepSeek Harness source checkout, prefix the commands with `pnpm`.
 
 ### 1. Install the plugin into one profile
 
 ```sh
-dsh plugin --profile web add dsh-codex-connect@alpha
+dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.22
 ```
 
 Expected result: the package is added to that profile. This does not change the profile's default model or global search route.
 
-After its matching package is published, install Alpha 4.22 exactly with `dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.22`.
+Use the exact version above to keep the verified DSH and plugin pair reproducible. `alpha` is a moving npm tag, not a compatibility guarantee.
 
 ### What's new in Alpha 4.22
 
@@ -36,6 +36,7 @@ After its matching package is published, install Alpha 4.22 exactly with `dsh pl
 - Manage ChatGPT authorization, quota and shared Codex Connect settings from a compact **Openai-Codex** card in **Settings → Models**, while retaining the original Plugin settings entry.
 - Continue, cancel or retry an interrupted browser authorization without restarting DSH or deleting an existing credential. The full authorization flow has a configurable bounded deadline.
 - Adjust a bounded local context budget per visible Codex model with a linked slider and numeric input. Catalog defaults remain in effect until an override is saved; the configuration limit is not a claim about the service-side context capacity.
+- Keep primary button labels readable in dark mode with theme-aware foreground and fill colors.
 
 ### Version updates
 
@@ -43,9 +44,7 @@ Codex Connect checks public package metadata and this repository's `verified-com
 
 The compatibility record lists exact plugin and DSH versions rather than assuming every later release remains compatible. Maintainers can add a newly verified DSH version to the repository file without publishing another plugin release. A green result means the installed pair was verified; yellow means the latest plugin was verified with the installed DSH version and should be installed first; red means the installed DSH version is known but neither the installed plugin nor the latest published plugin has a matching record; gray means the installed DSH version is not recorded or the public record could not be checked. A red result includes a prefilled GitHub issue link for the installed DSH version so users can remind the maintainer without composing a report from scratch.
 
-When a newer plugin version is available, a frame-wide DSH notice appears even if you switch conversations. It first shows the user-facing changes between your installed version and the newest version; technical release notes are available as a secondary detail, or from the release page. The plugin never runs an upgrade command by itself.
-
-The notice first summarizes the user-facing changes between your installed version and the newest version. Technical release notes remain available as a secondary detail. To update, copy the short request shown in the notice to the Agent you use for this DSH project. The Agent can inspect the project instructions and choose the appropriate install or update method; the plugin does not execute anything on your behalf.
+When a newer plugin version is available, a frame-wide DSH notice appears even if you switch conversations. It first shows the user-facing changes between your installed version and the newest version; technical release notes remain available as a secondary detail or from the release page. To update, copy the short request shown in the notice to the Agent you use for this DSH project. The Agent can inspect the project instructions and choose the appropriate install or update method; the plugin never runs an upgrade command itself.
 
 After the Agent reports completion, return to the notice or settings card and select **Done — check again**. If the running process still reports the old version, restart that profile's DSH Web process and check again.
 
@@ -65,15 +64,17 @@ dsh web
 
 Expected result: the Harness web UI opens for the selected profile.
 
-### 3. Find the Codex Connect card
+### 3. Find the Openai-Codex account card
 
-Open **Settings → Plugins → Plugin configuration → Codex Connect**.
+Open **Settings → Models** and find **Openai-Codex**. This is the primary Alpha 4.22 account entry. If the profile does not expose the Models settings section, open **Settings → Plugins → Plugin configuration → Codex Connect** instead.
 
-Alpha 4.22 for DSH `0.1.2-alpha.2` also includes an **Openai-Codex** account card in **Settings → Models**, with the attribution “Powered by the Codex Connect plugin.” for ChatGPT sign-in, reauthorization, sign-out and quota. Both pages share one in-memory account state and polling owner. **More settings** opens the existing proxy, model visibility, search, image and context-budget configuration form in a dialog; the original Plugin settings entry remains available. Both entries save to the same settings scope. Close or Escape discards unsaved dialog edits. The Models footer is optional: profiles without that settings section retain the existing Plugin entry.
+The Models card carries the attribution “Powered by the Codex Connect plugin.” and provides ChatGPT authorization, reauthorization, sign-out and quota. Both settings pages share one in-memory account state and polling owner. **More settings** opens the proxy, model visibility, search, image and context-budget configuration form in a dialog; the original Plugin settings entry remains available. Both entries save to the same settings scope. Close or Escape discards unsaved dialog edits. The Models footer is optional: profiles without that settings section retain the existing Plugin entry.
 
 The compact Models row shows **Authorize** when signed out, or **Sign out** and **View quota** when signed in. Expanding quota shows only the server-reported usage rows, without repeating account controls. If browser authorization is interrupted, use **Continue authorization** in Models (**Reopen authorization** in Plugins) to resume the pending login, or **Cancel sign-in** and retry from either settings page or another trusted browser. Cancellation preserves an existing signed-in account. An abandoned authorization expires after 10 minutes by default; the plugin's `oauthTimeoutMs` configuration accepts 1,000–1,800,000 milliseconds and applies when the plugin loads. The separate 30-second wait for the initial authorization URL remains bounded. Neither cancellation nor expiry restarts DSH.
 
-Expected result: a fresh installation shows **Not signed in** and a **Sign in with ChatGPT** button. The card is where you later manage optional capabilities too.
+Expected result: a fresh installation shows **Authorize** in Models. The Plugin configuration fallback shows **Not signed in** and **Sign in with ChatGPT**.
+
+The screenshot below shows the retained Plugin configuration fallback.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/plugin-entry.jpg" alt="Collapsed English-localized Codex Connect entry under Harness plugin configuration" width="586">
@@ -81,9 +82,9 @@ Expected result: a fresh installation shows **Not signed in** and a **Sign in wi
 
 ### 4. Sign in with ChatGPT
 
-Click **Sign in with ChatGPT** and complete the browser approval yourself. If an embedded WebView blocks the sign-in window, use the displayed **Open ChatGPT sign-in page** link to continue in your system browser. Do not copy an authorization URL, code, token, or account identifier into an issue, log, or configuration file.
+Select **Authorize** in Models, or **Sign in with ChatGPT** in Plugin configuration, and complete the browser approval yourself. If an embedded WebView blocks the sign-in window, use the displayed **Open ChatGPT sign-in page** link to continue in your system browser. Do not copy an authorization URL, code, token, or account identifier into an issue, log, or configuration file.
 
-Expected result: the account area changes to **Signed in**. The screenshot below is the successful end state after this step; it is not the initial sign-in screen.
+Expected result: Models shows **Sign out** and **View quota**. The Plugin configuration account area shows **Signed in**. The screenshot below shows that fallback view after a successful sign-in; it is not the initial sign-in screen.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/en/oauth-status.jpg" alt="English-localized Codex Connect signed-in state inside Harness plugin configuration" width="720">

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -18,17 +18,17 @@
 
 ## 五分钟快速开始
 
-本指南使用 `web` profile。请把 `web` 替换成你已经在用的 Harness profile 名称。你需要先有可用的 `dsh` 安装；如果在 DeepSeek Harness 源码 checkout 中运行，请在命令前加 `pnpm`。
+本快速指南适用于 DSH `0.1.2-alpha.2` 与 Codex Connect Alpha 4.22。请先运行 `dsh --version`。如果使用 DSH `0.1.1-rc.2` 或 `0.1.0-rc.7`，请在 [INSTALL.md](../INSTALL.md) 中选择匹配的插件版本。本指南使用 `web` profile；请把 `web` 替换成你已经在用的 Harness profile 名称。如果在 DeepSeek Harness 源码 checkout 中运行，请在命令前加 `pnpm`。
 
 ### 1. 将插件装入一个 profile
 
 ```sh
-dsh plugin --profile web add dsh-codex-connect@alpha
+dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.22
 ```
 
 预期结果：包被加入该 profile。这个动作不会更改 profile 的默认模型或全局搜索路由。
 
-匹配的 npm 包发布后，使用 `dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.22` 可以精确安装 Alpha 4.22。
+请使用上面的精确版本，确保已验证的 DSH 与插件组合可以复现。`alpha` 是会移动的 npm 标签，不是兼容性保证。
 
 ### Alpha 4.22 更新内容
 
@@ -36,6 +36,7 @@ dsh plugin --profile web add dsh-codex-connect@alpha
 - 在 **设置 → 模型** 中提供紧凑的 **Openai-Codex** 卡片，用于 ChatGPT 授权、额度和共享 Codex Connect 设置，同时保留原插件设置入口。
 - 浏览器授权中断后，可以继续、取消或重试，不需要重启 DSH，也不会删除已有凭据；完整授权流程使用可配置且有范围限制的期限。
 - 使用联动的滑条和数字输入框，逐模型调整有范围限制的本地上下文预算。保存覆盖值前继续使用目录默认值；配置上限不代表服务端上下文容量。
+- 使用跟随主题的前景色和填充色，确保深色模式下主按钮文字清晰可读。
 
 ### 版本更新提醒
 
@@ -65,15 +66,17 @@ dsh web
 
 预期结果：所选 profile 的 Harness Web UI 打开。
 
-### 3. 找到 Codex Connect 卡片
+### 3. 找到 Openai-Codex 账户卡
 
-打开 **设置 → 插件 → 插件配置 → Codex Connect**。
+打开 **设置 → 模型**，找到 **Openai-Codex**。这是 Alpha 4.22 的主要账户入口。如果当前 profile 没有模型设置分区，请改用 **设置 → 插件 → 插件配置 → Codex Connect**。
 
-面向 DSH `0.1.2-alpha.2` 的 Alpha 4.22 还在 **设置 → 模型** 中提供 **Openai-Codex** 账户卡，辅助文案标注“由 Codex Connect 插件提供支持。”，用于 ChatGPT 登录、重新授权、退出和查看额度。两个页面共用同一份内存账户状态及轮询。**更多设置** 会在弹窗中打开现有的代理、模型显示、搜索、图片和上下文预算配置表单，原插件设置入口仍保留。两处保存到同一份配置；关闭弹窗或按 Escape 会放弃弹窗内未保存的修改。模型页底部入口是可选增强：没有该设置分区的 profile 仍保留原插件入口。
+模型页账户卡标注“由 Codex Connect 插件提供支持。”，用于 ChatGPT 授权、重新授权、退出和查看额度。两个设置页面共用同一份内存账户状态及轮询。**更多设置** 会在弹窗中打开代理、模型显示、搜索、图片和上下文预算配置表单，原插件设置入口仍保留。两处保存到同一份配置；关闭弹窗或按 Escape 会放弃弹窗内未保存的修改。模型页底部入口是可选增强：没有该设置分区的 profile 仍保留原插件入口。
 
 模型页紧凑卡片在未登录时显示 **授权**，已登录时显示 **退出登录** 和 **查看额度**。展开后只显示服务端返回的额度条目，不再重复账户操作。浏览器授权中断后，可以点击模型页的 **继续授权**（插件页为 **重新打开授权**）继续原登录，或点击 **取消登录** 后，从任一设置页或另一个受信任浏览器重试。取消不会退出已有账户。未完成的授权默认在 10 分钟后到期；插件配置 `oauthTimeoutMs` 可设为 1,000–1,800,000 毫秒，在插件加载时生效。获取初始授权链接仍有独立的 30 秒等待上限。取消和到期都不需要重启 DSH。
 
-预期结果：新安装时账户区显示 **尚未登录**，并出现 **使用 ChatGPT 登录** 按钮。之后管理可选能力也在同一张卡片中完成。
+预期结果：新安装时模型页显示 **授权**。插件配置备用入口显示 **尚未登录** 和 **使用 ChatGPT 登录**。
+
+下图展示的是保留的插件配置备用入口。
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/plugin-entry.jpg" alt="Harness 插件配置中的中文 Codex Connect 折叠入口" width="586">
@@ -81,9 +84,9 @@ dsh web
 
 ### 4. 使用 ChatGPT 登录
 
-点击 **使用 ChatGPT 登录**，并自行完成浏览器审批。如果内嵌 WebView 阻止登录窗口，请点击页面显示的 **打开 ChatGPT 登录页面**，在系统浏览器中继续。不要把授权 URL、授权码、token 或账户标识复制到 Issue、日志或配置文件中。
+在模型页点击 **授权**，或在插件配置中点击 **使用 ChatGPT 登录**，然后自行完成浏览器审批。如果内嵌 WebView 阻止登录窗口，请点击页面显示的 **打开 ChatGPT 登录页面**，在系统浏览器中继续。不要把授权 URL、授权码、token 或账户标识复制到 Issue、日志或配置文件中。
 
-预期结果：账户区变为 **已登录**。下图展示的是完成本步骤后的成功状态，不是开始登录前的页面。
+预期结果：模型页显示 **退出登录** 和 **查看额度**；插件配置的账户区显示 **已登录**。下图展示的是成功登录后的备用入口，不是开始登录前的页面。
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/franksong2702/dsh-codex-connect/main/docs/assets/zh/oauth-status.jpg" alt="Harness 插件配置中的中文 Codex Connect 已登录状态" width="720">

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -42,9 +42,10 @@ const fullDescription = 'Connect your ChatGPT subscription to DeepSeek Harness w
 if (!readme.startsWith(`# Codex Connect\n\n[![npm version](https://img.shields.io/npm/v/dsh-codex-connect/alpha?label=npm%20alpha&color=cb3837)](https://www.npmjs.com/package/dsh-codex-connect)\n\nEnglish | [中文](docs/README.zh.md)\n\n${fullDescription}\n`)) {
   failures.push('README opening description mismatch')
 }
-if (!readme.includes('dsh plugin --profile web add dsh-codex-connect@alpha')) failures.push('README must prefer the npm alpha install command')
-if (!(await readFile(new URL('../docs/README.zh.md', import.meta.url), 'utf8')).includes('dsh plugin --profile web add dsh-codex-connect@alpha')) {
-  failures.push('Chinese README must prefer the npm alpha install command')
+const quickStartInstall = 'dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.22'
+if (!readme.includes(quickStartInstall)) failures.push('README must use the verified Alpha 4.22 install command')
+if (!(await readFile(new URL('../docs/README.zh.md', import.meta.url), 'utf8')).includes(quickStartInstall)) {
+  failures.push('Chinese README must use the verified Alpha 4.22 install command')
 }
 if (!readme.includes('Use the image generation capability included with your current GPT subscription.')) {
   failures.push('README must describe image generation with the approved subscription copy')


### PR DESCRIPTION
## Problem

Alpha 4.22 and its matching npm package are published, but the quick start still uses the moving `@alpha` tag and describes the exact package as a future release. The setup flow also treats Plugin configuration as the primary account entry even though Alpha 4.22 adds the Openai-Codex card under Settings → Models.

## Root cause

The release implementation and compatibility table were updated before publication, while the README quick start and its lint assertion retained the pre-release wording and older navigation order.

## Changes

- pin the English and Chinese quick starts to the verified Alpha 4.22 / DSH 0.1.2-alpha.2 pair
- make Settings → Models → Openai-Codex the primary account path and keep Plugin configuration as the documented fallback
- remove stale future-release wording and duplicate English update-notice prose
- add the Alpha 4.22 dark-mode button contrast improvement to both release summaries
- refresh the bilingual README pairing hashes and enforce the verified quick-start command in lint

## Verification

- `pnpm install --frozen-lockfile` — exit 0
- `node scripts/lint.mjs` — exit 0
- `pnpm exec vitest run tests/capability-docs.spec.ts tests/install-version-guidance.spec.ts` — exit 0; 2 files and 6 tests passed
- `pnpm run check:release-workflow` — exit 0; 30/30 assertions passed
- `git diff --cached --check` — exit 0

## Out of scope

- no runtime or UI implementation changes
- no new screenshots; the existing Plugin configuration captures are labeled as the retained fallback
- no changes from or to PR #80
