### PR TITLE
feat: probe hidden approval reviewer

### DIFF
--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   git hash-object README.md docs/README.zh.md
-README.md: 47599b77928c7dfc535c9544c357f0ee98b466e2
-docs/README.zh.md: 83998aac93878da15c4dbbe122e89b977ca44454
+README.md: f32699a6e74cd08bb8fd690172667909139516fc
+docs/README.zh.md: eb2909e967657d2afddd748bdeb94a7f414ece90

--- a/README.md
+++ b/README.md
@@ -306,6 +306,18 @@ The report labels each check `supported`, `rejected`, or `unknown`, with a reaso
 
 This report covers only the standalone route, not active profile routing, search/image tools, browser compatibility, provider retry behavior, or session recovery. Automatic provider failover is `rejected` because this plugin does not implement it; select an alternative provider explicitly. WebSocket-to-SSE fallback is inactive with the finite SSE default. `contextManagement` and continuation remain `unknown`; native compaction and WebSocket reuse are `rejected` by the current integration policy. No diagnostic result enables these capabilities or changes Harness history. Exit codes cover runtime, OAuth, selected model, Responses, and SSE only: `0` means all five were supported, `1` means at least one was rejected, and `2` means unknown evidence, invalid options, or an inspection failure. Rejected optional capabilities do not change that exit code.
 
+### Hidden approval-review capability probe
+
+Issue #84 is being investigated with a separate, opt-in probe. It does not add `codex-auto-review` to the model selector and does not review or execute a real Harness command.
+
+```sh
+dsh plugin --profile web exec dsh-codex-connect auto-review-probe --json
+```
+
+The command sends one fixed, synthetic no-op to the hidden reviewer through the ChatGPT OAuth Responses route. It requires an unexpired stored credential, never refreshes or writes credentials, does not follow redirects or retry, caps the response at 64 KiB, and destroys its owned connection before returning. `--proxy <http(s)-origin>` and `--timeout-ms <1..60000>` have the same explicit-network meaning as the ordinary capability probe.
+
+`supported` means only that the route accepted the exact hidden model id and returned one complete assessment matching the reviewer JSON fields. `rejected` means the request or local prerequisite was explicitly rejected. Timeouts, cancellation, malformed output, incomplete streams, rate limits, and network failures remain `unknown`. Output omits credentials, account ids, response ids, provider messages, model text, paths, headers, and proxy origins. Exit `0` requires runtime, OAuth, and reviewer checks to be supported; exit `1` means at least one was rejected; exit `2` means evidence is unknown or input is invalid. The report is evidence only: it never enables automatic approval, changes DSH policy, or authorizes an action.
+
 ## Compatibility and security boundary
 
 - Alpha 4.22 is verified with DSH plugin API packages `0.1.2-alpha.2`, `@earendil-works/pi-ai` `^0.84.2` (resolved as `0.84.4` during verification), and Node.js `^22.19.0 || >=24.0.0`. Published Alpha 4.21 remains verified with DSH `0.1.1-rc.2` and pi-ai `0.82.1`. [verified-compatibility.json](verified-compatibility.json) records the exact pairs; see [INSTALL.md](INSTALL.md) for installation commands.

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -308,6 +308,18 @@ dsh plugin --profile web exec dsh-codex-connect capabilities --model gpt-5.6-sol
 
 本报告仅涵盖独立路由，不验证活动 profile 路由、搜索/图片工具、浏览器兼容性、provider 重试行为或会话恢复。本插件没有实现自动 provider 故障切换，因此该项为 `rejected`，需要用户明确选择其他 provider。有限 SSE 默认路径不会触发 WebSocket 到 SSE 的回退。`contextManagement` 和续接仍为 `unknown`；原生 compaction 和 WebSocket reuse 在当前集成策略下为 `rejected`。诊断结果不会启用这些能力，也不会更改 Harness 历史。退出码只覆盖运行时、OAuth、所选模型、Responses 和 SSE：`0` 表示五项均可用，`1` 表示至少一项被拒绝，`2` 表示证据未知、选项无效或检查失败。被拒绝的可选能力不影响该退出码。
 
+### 隐藏审批审查能力探针
+
+Issue #84 使用一条独立、按需执行的探针开展调研。它不会把 `codex-auto-review` 加入模型选择器，也不会审查或执行真实的 Harness 命令。
+
+```sh
+dsh plugin --profile web exec dsh-codex-connect auto-review-probe --json
+```
+
+该命令通过 ChatGPT OAuth Responses 路由向隐藏 reviewer 发送一条固定的合成空操作。它要求已存凭据尚未过期，不刷新或写入凭据，不跟随重定向、不重试，响应上限为 64 KiB，并在返回前销毁自有连接。`--proxy <http(s)-origin>` 和 `--timeout-ms <1..60000>` 与普通能力探针具有相同的显式网络含义。
+
+`supported` 只表示路由接受了精确的隐藏模型 ID，并返回一条符合 reviewer JSON 字段的完整审查结果。`rejected` 表示请求或本地前置条件被明确拒绝。超时、取消、格式错误、不完整流、限流和网络故障均保持 `unknown`。输出会省略凭据、账号 ID、response ID、服务端消息、模型文本、路径、headers 和代理 origin。只有运行时、OAuth 和 reviewer 三项均为可用时才返回 `0`；至少一项被拒绝时返回 `1`；证据未知或输入无效时返回 `2`。该报告只提供证据：它绝不会启用自动审批、修改 DSH 策略或授权任何操作。
+
 ## 兼容性与安全边界
 
 - Alpha 4.22 已与 DSH 插件 API packages `0.1.2-alpha.2`、`@earendil-works/pi-ai` `^0.84.2`（验证时解析为 `0.84.4`）和 Node.js `^22.19.0 || >=24.0.0` 完成验证。已发布 Alpha 4.21 仍与 DSH `0.1.1-rc.2` 和 pi-ai `0.82.1` 保持已验证状态。[verified-compatibility.json](../verified-compatibility.json) 记录精确组合；安装命令见 [INSTALL.md](../INSTALL.md)。

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -9,17 +9,17 @@ import { createInterface } from "node:readline/promises";
 //#region src/capability-probe.ts
 /** Bounded, standalone Responses probe; never used by conversation routing. */
 /** A security limit, not a model output-token setting. */
-const MAX_PROBE_RESPONSE_BYTES = 65536;
-function record(value) {
+const MAX_PROBE_RESPONSE_BYTES$1 = 65536;
+function record$1(value) {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
-function completedResponse(value, model) {
-	if (!record(value) || value["status"] !== "completed" || !Array.isArray(value["output"])) return false;
+function completedResponse$1(value, model) {
+	if (!record$1(value) || value["status"] !== "completed" || !Array.isArray(value["output"])) return false;
 	if (value["model"] !== model) return false;
-	return value["output"].some((item) => record(item) && item["type"] === "message" && item["role"] === "assistant" && Array.isArray(item["content"]) && item["content"].some((part) => record(part) && part["type"] === "output_text" && typeof part["text"] === "string" && part["text"].trim().length > 0));
+	return value["output"].some((item) => record$1(item) && item["type"] === "message" && item["role"] === "assistant" && Array.isArray(item["content"]) && item["content"].some((part) => record$1(part) && part["type"] === "output_text" && typeof part["text"] === "string" && part["text"].trim().length > 0));
 }
 /** Inspect complete SSE frames, not substrings inside error text or schema errors. */
-function completedStream(text, model) {
+function completedStream$1(text, model) {
 	let completed = false;
 	let data = [];
 	for (const line of text.split(/\r\n|\r|\n/u)) if (line === "") {
@@ -33,10 +33,10 @@ function completedStream(text, model) {
 		} catch {
 			return false;
 		}
-		if (!record(event)) return false;
+		if (!record$1(event)) return false;
 		if (event["type"] === "error" || event["type"] === "response.failed" || event["type"] === "response.incomplete") return false;
 		if (event["type"] === "response.completed" || event["type"] === "response.done") {
-			if (completed || !completedResponse(event["response"], model)) return false;
+			if (completed || !completedResponse$1(event["response"], model)) return false;
 			completed = true;
 		}
 	} else if (line.startsWith("data:")) data.push(line.slice(5).replace(/^ /u, ""));
@@ -112,7 +112,7 @@ async function probeCodexResponses(request, createDispatcher = (proxyUrl) => pro
 				const { value, done } = await reader.read();
 				if (done) break;
 				size += value.byteLength;
-				if (size > MAX_PROBE_RESPONSE_BYTES) {
+				if (size > MAX_PROBE_RESPONSE_BYTES$1) {
 					await reader.cancel();
 					return {
 						outcome: "incomplete",
@@ -125,7 +125,7 @@ async function probeCodexResponses(request, createDispatcher = (proxyUrl) => pro
 			reader.releaseLock();
 		}
 		return {
-			outcome: completedStream(new TextDecoder("utf-8", { fatal: true }).decode(Buffer.concat(chunks)), request.model) ? "completed" : "incomplete",
+			outcome: completedStream$1(new TextDecoder("utf-8", { fatal: true }).decode(Buffer.concat(chunks)), request.model) ? "completed" : "incomplete",
 			httpStatus
 		};
 	} catch {
@@ -151,7 +151,7 @@ function result(status, reason, action) {
 function safeVersion(value) {
 	return value !== null && value !== void 0 && /^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/u.test(value) ? value : null;
 }
-function observed(evidence) {
+function observed$1(evidence) {
 	switch (evidence.outcome) {
 		case "completed": return result("supported", "completed-response-for-selected-model", "This proves only the fixed standalone prompt; test the active Harness profile separately.");
 		case "http-rejected": switch (evidence.httpStatus) {
@@ -295,7 +295,7 @@ var CodexCapabilityDiagnostics = class {
 			};
 		}
 		if (evidence.httpStatus !== void 0) report.probe.httpStatus = evidence.httpStatus;
-		checks.responses = observed(evidence);
+		checks.responses = observed$1(evidence);
 		checks.transport = { ...checks.responses };
 		if (evidence.outcome === "completed") {
 			checks.oauth = result("supported", "authorized-completed-response", "Authorization succeeded for this model and fixed request at the recorded time only.");
@@ -369,6 +369,299 @@ async function runCapabilityCommand(args) {
 	}
 }
 //#endregion
+//#region src/auto-review-probe.ts
+/** Fixed, standalone probe for the hidden Codex approval reviewer. */
+/** Hidden reviewer route selected by the first-party Codex catalog. */
+const CODEX_AUTO_REVIEW_MODEL = "codex-auto-review";
+/** A response-reading limit, not a model output-token setting. */
+const MAX_PROBE_RESPONSE_BYTES = 65536;
+const instructions = "This is a capability diagnostic. Do not call tools or execute any action. Return strict JSON for the supplied synthetic approval request. For this fixed low-risk no-op, return {\"outcome\":\"allow\"}.";
+const input = "Synthetic approval request only; nothing will be executed. Planned action JSON: {\"type\":\"diagnostic-no-op\",\"sideEffects\":false}";
+function record(value) {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function assessment(text) {
+	let value;
+	try {
+		value = JSON.parse(text);
+	} catch {
+		return false;
+	}
+	if (!record(value)) return false;
+	if (Object.keys(value).some((key) => ![
+		"risk_level",
+		"user_authorization",
+		"outcome",
+		"rationale"
+	].includes(key))) return false;
+	if (!["allow", "deny"].includes(String(value["outcome"]))) return false;
+	if (value["risk_level"] !== void 0 && ![
+		"low",
+		"medium",
+		"high",
+		"critical"
+	].includes(String(value["risk_level"]))) return false;
+	if (value["user_authorization"] !== void 0 && ![
+		"unknown",
+		"low",
+		"medium",
+		"high"
+	].includes(String(value["user_authorization"]))) return false;
+	return value["rationale"] === void 0 || typeof value["rationale"] === "string";
+}
+function completedResponse(value) {
+	if (!record(value) || value["status"] !== "completed" || value["model"] !== "codex-auto-review" || !Array.isArray(value["output"])) return false;
+	const texts = value["output"].flatMap((item) => record(item) && item["type"] === "message" && item["role"] === "assistant" && Array.isArray(item["content"]) ? item["content"].flatMap((part) => record(part) && part["type"] === "output_text" && typeof part["text"] === "string" ? [part["text"]] : []) : []);
+	return texts.length === 1 && assessment(texts[0]);
+}
+/** Inspect complete SSE frames and accept exactly one matching terminal response. */
+function completedStream(text) {
+	let completed = false;
+	let data = [];
+	for (const line of text.split(/\r\n|\r|\n/u)) if (line === "") {
+		if (data.length === 0) continue;
+		const payload = data.join("\n");
+		data = [];
+		if (payload === "[DONE]") continue;
+		let event;
+		try {
+			event = JSON.parse(payload);
+		} catch {
+			return false;
+		}
+		if (!record(event) || event["type"] === "error" || event["type"] === "response.failed" || event["type"] === "response.incomplete") return false;
+		if (event["type"] === "response.completed" || event["type"] === "response.done") {
+			if (completed || !completedResponse(event["response"])) return false;
+			completed = true;
+		}
+	} else if (line.startsWith("data:")) data.push(line.slice(5).replace(/^ /u, ""));
+	return completed && data.length === 0;
+}
+/**
+* Send one secret-free synthetic approval to the hidden reviewer model.
+* The result is evidence only and never authorizes or executes an action.
+* @param request - OAuth credential, explicit network policy, deadline, and optional cancellation.
+* @param createDispatcher - owned connection factory; tests use an offline dispatcher.
+* @returns bounded evidence without model-generated or provider error text.
+*/
+async function probeCodexAutoReview(request, createDispatcher = (proxyUrl) => proxyUrl === void 0 ? new Agent() : new ProxyAgent(proxyUrl)) {
+	const dispatcher = createDispatcher(request.proxyUrl);
+	const controller = new AbortController();
+	let timedOut = false;
+	let cancelled = request.signal?.aborted ?? false;
+	const cancel = () => {
+		cancelled = true;
+		controller.abort();
+	};
+	request.signal?.addEventListener("abort", cancel, { once: true });
+	if (cancelled) controller.abort();
+	const timer = setTimeout(() => {
+		timedOut = true;
+		controller.abort();
+	}, request.timeoutMs);
+	let httpStatus;
+	try {
+		const response = await fetch(`${OPENAI_CODEX_BASE_URL}/responses`, {
+			dispatcher,
+			method: "POST",
+			redirect: "manual",
+			signal: controller.signal,
+			headers: {
+				authorization: `Bearer ${request.access}`,
+				"chatgpt-account-id": request.accountId,
+				"content-type": "application/json",
+				accept: "text/event-stream",
+				originator: "deepseek-harness"
+			},
+			body: JSON.stringify({
+				model: CODEX_AUTO_REVIEW_MODEL,
+				instructions,
+				input: [{
+					role: "user",
+					content: [{
+						type: "input_text",
+						text: input
+					}]
+				}],
+				stream: true,
+				store: false
+			})
+		});
+		httpStatus = response.status;
+		if (!response.ok) {
+			await response.body?.cancel();
+			return {
+				outcome: [
+					400,
+					401,
+					403,
+					404,
+					405,
+					422
+				].includes(httpStatus) ? "http-rejected" : "transient",
+				httpStatus
+			};
+		}
+		if (httpStatus !== 200 || !response.headers.get("content-type")?.toLowerCase().startsWith("text/event-stream") || response.body === null) {
+			await response.body?.cancel();
+			return {
+				outcome: "incomplete",
+				httpStatus
+			};
+		}
+		const reader = response.body.getReader();
+		const chunks = [];
+		let size = 0;
+		try {
+			while (true) {
+				const { value, done } = await reader.read();
+				if (done) break;
+				size += value.byteLength;
+				if (size > MAX_PROBE_RESPONSE_BYTES) {
+					await reader.cancel();
+					return {
+						outcome: "incomplete",
+						httpStatus
+					};
+				}
+				chunks.push(value);
+			}
+		} finally {
+			reader.releaseLock();
+		}
+		return {
+			outcome: completedStream(new TextDecoder("utf-8", { fatal: true }).decode(Buffer.concat(chunks))) ? "completed" : "incomplete",
+			httpStatus
+		};
+	} catch {
+		return {
+			outcome: cancelled ? "cancelled" : timedOut ? "timeout" : "network-error",
+			...httpStatus === void 0 ? {} : { httpStatus }
+		};
+	} finally {
+		clearTimeout(timer);
+		request.signal?.removeEventListener("abort", cancel);
+		await dispatcher.destroy();
+	}
+}
+//#endregion
+//#region src/auto-review-cli.ts
+/** Opt-in diagnostic for the hidden Codex approval reviewer. */
+function check(status, reason, action) {
+	return {
+		status,
+		reason,
+		action
+	};
+}
+function observed(evidence) {
+	switch (evidence.outcome) {
+		case "completed": return check("supported", "completed-structured-review", "The OAuth route accepted the hidden reviewer and returned its approval schema; this does not enable DSH approval integration.");
+		case "http-rejected": return check("rejected", `http-${String(evidence.httpStatus ?? "rejected")}`, "The supported OAuth route rejected this hidden reviewer request; keep automatic approval disabled.");
+		case "transient": return check("unknown", "transient-or-redirect-response", "Check network, quota, or service availability before explicitly retrying.");
+		case "incomplete": return check("unknown", "no-complete-structured-review", "HTTP success without one matching structured assessment is not capability evidence.");
+		case "timeout": return check("unknown", "probe-deadline", "The diagnostic exceeded its deadline; no approval capability was established.");
+		case "cancelled": return check("unknown", "probe-cancelled", "The diagnostic was cancelled; no approval capability was established.");
+		case "network-error": return check("unknown", "network-or-stream-error", "Check the network or pass an explicit --proxy; no server decision was confirmed.");
+	}
+}
+/** Run the standalone reviewer probe without booting Harness or changing settings. */
+async function runAutoReviewProbeCommand(args, deps = {
+	diagnose: diagnoseOpenAICodex,
+	credentials: new OpenAICodexCredentialStore(),
+	probe: probeCodexAutoReview,
+	now: Date.now
+}) {
+	let json = false;
+	let proxyUrl;
+	let timeoutMs = 3e4;
+	const seen = /* @__PURE__ */ new Set();
+	const invalid = () => {
+		process.stderr.write("Usage: dsh-codex-connect auto-review-probe [--proxy <http(s)-origin>] [--timeout-ms <1..60000>] [--json]\n");
+		return 2;
+	};
+	for (let index = 0; index < args.length; index += 1) {
+		const flag = args[index];
+		if (seen.has(flag)) return invalid();
+		seen.add(flag);
+		if (flag === "--json") json = true;
+		else if (flag === "--proxy" || flag === "--timeout-ms") {
+			const value = args[++index];
+			if (value === void 0 || value.startsWith("--")) return invalid();
+			if (flag === "--proxy") {
+				proxyUrl = normalizeOpenAICodexProxyUrl(value);
+				if (proxyUrl === void 0) return invalid();
+			} else {
+				if (!/^\d+$/u.test(value) || Number(value) < 1 || Number(value) > 6e4) return invalid();
+				timeoutMs = Number(value);
+			}
+		} else return invalid();
+	}
+	const local = await deps.diagnose();
+	const runtime = local.compatibility.status === "compatible" ? check("supported", "declared-host-versions-match", "Installed package versions satisfy the probe prerequisites; this is not active-profile validation.") : check(local.compatibility.status === "incompatible" ? "rejected" : "unknown", "runtime-compatibility-unavailable", "Install the supported Codex Connect and DSH package set before probing.");
+	let oauth = local.credentialFile.state === "owner-only" ? check("unknown", "credential-metadata-only", "An owner-only file does not prove authorization; the explicit probe reads its unexpired stored credential.") : check("rejected", "credential-file-unusable", "Sign in or repair the owner-only credential file before probing.");
+	let reviewer = check("unknown", "not-probed", "Run this command explicitly only when one fixed diagnostic request is acceptable.");
+	let probe = { state: "skipped" };
+	if (runtime.status === "supported" && oauth.status !== "rejected") {
+		let credential;
+		try {
+			credential = await deps.credentials.read(OPENAI_CODEX_PROVIDER);
+		} catch {
+			oauth = check("rejected", "credential-unreadable", "Repair the credential file or sign in again; diagnostic output omits parser details.");
+		}
+		if (credential?.type !== "oauth" || typeof credential.accountId !== "string") {
+			if (oauth.reason !== "credential-unreadable") oauth = check("rejected", "credential-missing", "Sign in before explicitly probing the hidden reviewer.");
+		} else if (credential.expires <= deps.now()) oauth = check("unknown", "access-token-expired", "Use the normal sign-in or refresh flow, then repeat the probe; diagnostics never refresh credentials.");
+		else {
+			let evidence;
+			try {
+				evidence = await deps.probe({
+					access: credential.access,
+					accountId: credential.accountId,
+					proxyUrl,
+					timeoutMs
+				});
+			} catch {
+				evidence = { outcome: "network-error" };
+			}
+			probe = {
+				state: "fresh",
+				...evidence.httpStatus === void 0 ? {} : { httpStatus: evidence.httpStatus }
+			};
+			reviewer = observed(evidence);
+			if (evidence.outcome === "completed") oauth = check("supported", "authorized-completed-review", "Authorization succeeded for this fixed reviewer request at the recorded time only.");
+			else if (evidence.httpStatus === 401) oauth = check("rejected", "http-401", "Sign in again, then explicitly repeat the probe.");
+		}
+	}
+	const report = {
+		schemaVersion: 1,
+		package: "dsh-codex-connect",
+		version: CODEX_CONNECT_VERSION,
+		scope: "auto-review-route-only",
+		model: CODEX_AUTO_REVIEW_MODEL,
+		network: proxyUrl === void 0 ? "direct" : "explicit-proxy",
+		checks: {
+			runtime,
+			oauth,
+			reviewer
+		},
+		probe
+	};
+	process.stdout.write(json ? `${JSON.stringify(report)}\n` : [
+		`Codex Connect ${report.version}: hidden approval-review capability probe`,
+		"Scope: one synthetic no-op; no command is executed and no approval integration is enabled.",
+		`Model: ${report.model}; network: ${report.network}; probe: ${report.probe.state}`,
+		...Object.entries(report.checks).map(([id, value]) => `${id}: ${value.status} (${value.reason})\n  ${value.action}`),
+		""
+	].join("\n"));
+	const primary = [
+		runtime,
+		oauth,
+		reviewer
+	];
+	return primary.some((value) => value.status === "rejected") ? 1 : primary.some((value) => value.status === "unknown") ? 2 : 0;
+}
+//#endregion
 //#region src/bin.ts
 /** Standalone credential CLI for the optional OpenAI Codex bundle. */
 const JSON_SCHEMA_VERSION = 1;
@@ -435,8 +728,10 @@ function printHelp() {
 		"       dsh-codex-connect trusted-origins [--json]",
 		"       dsh-codex-connect untrust-origin <origin>",
 		"       dsh-codex-connect capabilities [--model <catalog-id>] [--probe] [--proxy <http(s)-origin>] [--timeout-ms <1..60000>] [--json]",
+		"       dsh-codex-connect auto-review-probe [--proxy <http(s)-origin>] [--timeout-ms <1..60000>] [--json]",
 		"",
 		"  doctor         inspect secret-free runtime and OAuth file metadata",
+		"  auto-review-probe test the hidden approval reviewer with one synthetic no-op",
 		"  login          sign in with a separate ChatGPT OAuth session",
 		"  logout         remove the dsh credential without changing ~/.codex",
 		"  migrate-history find or repair Alpha 4.10 private search events (dry-run by default)",
@@ -445,7 +740,7 @@ function printHelp() {
 		"  trusted-origins list the currently allowed browser origins",
 		"  untrust-origin remove one exact browser origin from the allowlist",
 		"  --device-code  use headless device-code login (login only)",
-		"  --json         emit one JSON document (doctor/status/trusted-origins/migrate-history)",
+		"  --json         emit one JSON document (doctor/status/capabilities/auto-review-probe/trusted-origins/migrate-history)",
 		""
 	].join("\n"));
 }
@@ -483,6 +778,7 @@ async function run(argv) {
 	}
 	const [rawAction, ...flags] = argv;
 	if (rawAction === "capabilities") return runCapabilityCommand(flags);
+	if (rawAction === "auto-review-probe") return runAutoReviewProbeCommand(flags);
 	if (![
 		"doctor",
 		"login",

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -375,8 +375,43 @@ async function runCapabilityCommand(args) {
 const CODEX_AUTO_REVIEW_MODEL = "codex-auto-review";
 /** A response-reading limit, not a model output-token setting. */
 const MAX_PROBE_RESPONSE_BYTES = 65536;
-const instructions = "This is a capability diagnostic. Do not call tools or execute any action. Return strict JSON for the supplied synthetic approval request. For this fixed low-risk no-op, return {\"outcome\":\"allow\"}.";
+const instructions = "This is a capability diagnostic. Do not call tools or execute any action. Return one strict JSON assessment for the supplied synthetic approval request, including risk_level, user_authorization, outcome, and rationale.";
 const input = "Synthetic approval request only; nothing will be executed. Planned action JSON: {\"type\":\"diagnostic-no-op\",\"sideEffects\":false}";
+const assessmentSchema = {
+	type: "object",
+	additionalProperties: false,
+	properties: {
+		risk_level: {
+			type: "string",
+			enum: [
+				"low",
+				"medium",
+				"high",
+				"critical"
+			]
+		},
+		user_authorization: {
+			type: "string",
+			enum: [
+				"unknown",
+				"low",
+				"medium",
+				"high"
+			]
+		},
+		outcome: {
+			type: "string",
+			enum: ["allow", "deny"]
+		},
+		rationale: { type: "string" }
+	},
+	required: [
+		"risk_level",
+		"user_authorization",
+		"outcome",
+		"rationale"
+	]
+};
 function record(value) {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -410,13 +445,14 @@ function assessment(text) {
 	return value["rationale"] === void 0 || typeof value["rationale"] === "string";
 }
 function completedResponse(value) {
-	if (!record(value) || value["status"] !== "completed" || value["model"] !== "codex-auto-review" || !Array.isArray(value["output"])) return false;
-	const texts = value["output"].flatMap((item) => record(item) && item["type"] === "message" && item["role"] === "assistant" && Array.isArray(item["content"]) ? item["content"].flatMap((part) => record(part) && part["type"] === "output_text" && typeof part["text"] === "string" ? [part["text"]] : []) : []);
-	return texts.length === 1 && assessment(texts[0]);
+	if (!record(value) || value["status"] !== "completed" || typeof value["model"] !== "string" || !Array.isArray(value["output"])) return void 0;
+	return value["output"].flatMap((item) => record(item) && item["type"] === "message" && item["role"] === "assistant" && Array.isArray(item["content"]) ? item["content"].flatMap((part) => record(part) && part["type"] === "output_text" && typeof part["text"] === "string" ? [part["text"]] : []) : []);
 }
 /** Inspect complete SSE frames and accept exactly one matching terminal response. */
 function completedStream(text) {
 	let completed = false;
+	let terminalTexts;
+	const streamedTexts = [];
 	let data = [];
 	for (const line of text.split(/\r\n|\r|\n/u)) if (line === "") {
 		if (data.length === 0) continue;
@@ -430,12 +466,19 @@ function completedStream(text) {
 			return false;
 		}
 		if (!record(event) || event["type"] === "error" || event["type"] === "response.failed" || event["type"] === "response.incomplete") return false;
+		if (event["type"] === "response.output_text.done") {
+			if (typeof event["text"] !== "string") return false;
+			streamedTexts.push(event["text"]);
+		}
 		if (event["type"] === "response.completed" || event["type"] === "response.done") {
-			if (completed || !completedResponse(event["response"])) return false;
+			terminalTexts = completedResponse(event["response"]);
+			if (completed || terminalTexts === void 0) return false;
 			completed = true;
 		}
 	} else if (line.startsWith("data:")) data.push(line.slice(5).replace(/^ /u, ""));
-	return completed && data.length === 0;
+	if (!completed || data.length !== 0) return false;
+	const texts = terminalTexts.length > 0 ? terminalTexts : streamedTexts;
+	return texts.length === 1 && assessment(texts[0]);
 }
 /**
 * Send one secret-free synthetic approval to the hidden reviewer model.
@@ -483,6 +526,12 @@ async function probeCodexAutoReview(request, createDispatcher = (proxyUrl) => pr
 						text: input
 					}]
 				}],
+				text: { format: {
+					type: "json_schema",
+					name: "codex_auto_review_assessment",
+					strict: true,
+					schema: assessmentSchema
+				} },
 				stream: true,
 				store: false
 			})
@@ -502,7 +551,8 @@ async function probeCodexAutoReview(request, createDispatcher = (proxyUrl) => pr
 				httpStatus
 			};
 		}
-		if (httpStatus !== 200 || !response.headers.get("content-type")?.toLowerCase().startsWith("text/event-stream") || response.body === null) {
+		const contentType = response.headers.get("content-type");
+		if (httpStatus !== 200 || contentType !== null && !contentType.toLowerCase().startsWith("text/event-stream") || response.body === null) {
 			await response.body?.cancel();
 			return {
 				outcome: "incomplete",

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -429,20 +429,20 @@ function assessment(text) {
 		"outcome",
 		"rationale"
 	].includes(key))) return false;
-	if (!["allow", "deny"].includes(String(value["outcome"]))) return false;
-	if (value["risk_level"] !== void 0 && ![
+	if (![
 		"low",
 		"medium",
 		"high",
 		"critical"
 	].includes(String(value["risk_level"]))) return false;
-	if (value["user_authorization"] !== void 0 && ![
+	if (![
 		"unknown",
 		"low",
 		"medium",
 		"high"
 	].includes(String(value["user_authorization"]))) return false;
-	return value["rationale"] === void 0 || typeof value["rationale"] === "string";
+	if (!["allow", "deny"].includes(String(value["outcome"]))) return false;
+	return typeof value["rationale"] === "string";
 }
 function completedResponse(value) {
 	if (!record(value) || value["status"] !== "completed" || typeof value["model"] !== "string" || !Array.isArray(value["output"])) return void 0;

--- a/scripts/check-capability-cli.mjs
+++ b/scripts/check-capability-cli.mjs
@@ -28,8 +28,8 @@ server.on('connect', (_req, socket) => {
 const env = Object.fromEntries(['PATH', 'SystemRoot', 'SYSTEMROOT', 'WINDIR', 'TEMP', 'TMP'].flatMap(key => process.env[key] === undefined ? [] : [[key, process.env[key]]]))
 env.DSH_HOME = root
 
-async function command(args) {
-  const result = await runBoundedCommand(process.execPath, [bin, 'capabilities', ...args, '--json'], { env, timeoutMs: 10_000 })
+async function command(action, args) {
+  const result = await runBoundedCommand(process.execPath, [bin, action, ...args, '--json'], { env, timeoutMs: 10_000 })
   assert.equal(result.error, undefined)
   assert.equal(result.cleanupError, undefined)
   assert.equal(result.signal, null)
@@ -39,7 +39,7 @@ async function command(args) {
 }
 
 try {
-  const offline = await command(['--model', 'gpt-5.6-sol'])
+  const offline = await command('capabilities', ['--model', 'gpt-5.6-sol'])
   assert.equal(offline.code, 1)
   assert.equal(offline.report.checks.runtime.status, 'supported')
   assert.equal(offline.report.probe.state, 'not-requested')
@@ -50,11 +50,15 @@ try {
   })
   const address = server.address()
   assert.ok(address !== null && typeof address !== 'string')
-  const probed = await command(['--model', 'gpt-5.6-sol', '--probe', '--proxy', `http://127.0.0.1:${address.port}`, '--timeout-ms', '1000'])
+  const probed = await command('capabilities', ['--model', 'gpt-5.6-sol', '--probe', '--proxy', `http://127.0.0.1:${address.port}`, '--timeout-ms', '1000'])
   assert.equal(probed.code, 2)
   assert.equal(probed.report.probe.state, 'fresh')
   assert.equal(probed.report.checks.responses.status, 'unknown')
-  assert.equal(connects, 1)
+  const reviewed = await command('auto-review-probe', ['--proxy', `http://127.0.0.1:${address.port}`, '--timeout-ms', '1000'])
+  assert.equal(reviewed.code, 2)
+  assert.equal(reviewed.report.probe.state, 'fresh')
+  assert.equal(reviewed.report.checks.reviewer.status, 'unknown')
+  assert.equal(connects, 2)
   assert.equal(sockets.size, 0)
   assert.equal(await readFile(authFile, 'utf8'), credential)
   process.stdout.write('capability-cli: offline report, explicit proxy rejection, unchanged credentials, and natural child exit verified\n')

--- a/src/auto-review-cli.ts
+++ b/src/auto-review-cli.ts
@@ -1,0 +1,132 @@
+/** Opt-in diagnostic for the hidden Codex approval reviewer. */
+
+import { diagnoseOpenAICodex } from './doctor.ts'
+import { normalizeOpenAICodexProxyUrl } from './settings-contract.ts'
+import { OPENAI_CODEX_PROVIDER, OpenAICodexCredentialStore } from './store.ts'
+import { CODEX_CONNECT_VERSION } from './version.ts'
+import { CODEX_AUTO_REVIEW_MODEL, probeCodexAutoReview } from './auto-review-probe.ts'
+import type { AutoReviewProbeEvidence, AutoReviewProbeRequest } from './auto-review-probe.ts'
+
+type Status = 'supported' | 'rejected' | 'unknown'
+
+interface Check {
+  status: Status
+  reason: string
+  action: string
+}
+
+export interface AutoReviewProbeDependencies {
+  diagnose: typeof diagnoseOpenAICodex
+  credentials: Pick<OpenAICodexCredentialStore, 'read'>
+  probe: (request: AutoReviewProbeRequest) => Promise<AutoReviewProbeEvidence>
+  now: () => number
+}
+
+function check(status: Status, reason: string, action: string): Check {
+  return { status, reason, action }
+}
+
+function observed(evidence: AutoReviewProbeEvidence): Check {
+  switch (evidence.outcome) {
+    case 'completed': return check('supported', 'completed-structured-review', 'The OAuth route accepted the hidden reviewer and returned its approval schema; this does not enable DSH approval integration.')
+    case 'http-rejected': return check('rejected', `http-${String(evidence.httpStatus ?? 'rejected')}`, 'The supported OAuth route rejected this hidden reviewer request; keep automatic approval disabled.')
+    case 'transient': return check('unknown', 'transient-or-redirect-response', 'Check network, quota, or service availability before explicitly retrying.')
+    case 'incomplete': return check('unknown', 'no-complete-structured-review', 'HTTP success without one matching structured assessment is not capability evidence.')
+    case 'timeout': return check('unknown', 'probe-deadline', 'The diagnostic exceeded its deadline; no approval capability was established.')
+    case 'cancelled': return check('unknown', 'probe-cancelled', 'The diagnostic was cancelled; no approval capability was established.')
+    case 'network-error': return check('unknown', 'network-or-stream-error', 'Check the network or pass an explicit --proxy; no server decision was confirmed.')
+  }
+}
+
+/** Run the standalone reviewer probe without booting Harness or changing settings. */
+export async function runAutoReviewProbeCommand(
+  args: readonly string[],
+  deps: AutoReviewProbeDependencies = {
+    diagnose: diagnoseOpenAICodex,
+    credentials: new OpenAICodexCredentialStore(),
+    probe: probeCodexAutoReview,
+    now: Date.now,
+  },
+): Promise<number> {
+  let json = false
+  let proxyUrl: string | undefined
+  let timeoutMs = 30_000
+  const seen = new Set<string>()
+  const invalid = (): number => {
+    process.stderr.write('Usage: dsh-codex-connect auto-review-probe [--proxy <http(s)-origin>] [--timeout-ms <1..60000>] [--json]\n')
+    return 2
+  }
+  for (let index = 0; index < args.length; index += 1) {
+    const flag = args[index]!
+    if (seen.has(flag)) return invalid()
+    seen.add(flag)
+    if (flag === '--json') json = true
+    else if (flag === '--proxy' || flag === '--timeout-ms') {
+      const value = args[++index]
+      if (value === undefined || value.startsWith('--')) return invalid()
+      if (flag === '--proxy') {
+        proxyUrl = normalizeOpenAICodexProxyUrl(value)
+        if (proxyUrl === undefined) return invalid()
+      } else {
+        if (!/^\d+$/u.test(value) || Number(value) < 1 || Number(value) > 60_000) return invalid()
+        timeoutMs = Number(value)
+      }
+    } else return invalid()
+  }
+
+  const local = await deps.diagnose()
+  const runtime = local.compatibility.status === 'compatible'
+    ? check('supported', 'declared-host-versions-match', 'Installed package versions satisfy the probe prerequisites; this is not active-profile validation.')
+    : check(local.compatibility.status === 'incompatible' ? 'rejected' : 'unknown', 'runtime-compatibility-unavailable', 'Install the supported Codex Connect and DSH package set before probing.')
+  let oauth = local.credentialFile.state === 'owner-only'
+    ? check('unknown', 'credential-metadata-only', 'An owner-only file does not prove authorization; the explicit probe reads its unexpired stored credential.')
+    : check('rejected', 'credential-file-unusable', 'Sign in or repair the owner-only credential file before probing.')
+  let reviewer = check('unknown', 'not-probed', 'Run this command explicitly only when one fixed diagnostic request is acceptable.')
+  let probe: { state: 'skipped' | 'fresh'; httpStatus?: number } = { state: 'skipped' }
+
+  if (runtime.status === 'supported' && oauth.status !== 'rejected') {
+    let credential
+    try {
+      credential = await deps.credentials.read(OPENAI_CODEX_PROVIDER)
+    } catch {
+      oauth = check('rejected', 'credential-unreadable', 'Repair the credential file or sign in again; diagnostic output omits parser details.')
+    }
+    if (credential?.type !== 'oauth' || typeof credential.accountId !== 'string') {
+      if (oauth.reason !== 'credential-unreadable') oauth = check('rejected', 'credential-missing', 'Sign in before explicitly probing the hidden reviewer.')
+    } else if (credential.expires <= deps.now()) {
+      oauth = check('unknown', 'access-token-expired', 'Use the normal sign-in or refresh flow, then repeat the probe; diagnostics never refresh credentials.')
+    } else {
+      let evidence: AutoReviewProbeEvidence
+      try {
+        evidence = await deps.probe({ access: credential.access, accountId: credential.accountId, proxyUrl, timeoutMs })
+      } catch {
+        // A provider or dispatcher failure can include credentials or response text.
+        evidence = { outcome: 'network-error' }
+      }
+      probe = { state: 'fresh', ...evidence.httpStatus === undefined ? {} : { httpStatus: evidence.httpStatus } }
+      reviewer = observed(evidence)
+      if (evidence.outcome === 'completed') oauth = check('supported', 'authorized-completed-review', 'Authorization succeeded for this fixed reviewer request at the recorded time only.')
+      else if (evidence.httpStatus === 401) oauth = check('rejected', 'http-401', 'Sign in again, then explicitly repeat the probe.')
+    }
+  }
+
+  const report = {
+    schemaVersion: 1,
+    package: 'dsh-codex-connect',
+    version: CODEX_CONNECT_VERSION,
+    scope: 'auto-review-route-only',
+    model: CODEX_AUTO_REVIEW_MODEL,
+    network: proxyUrl === undefined ? 'direct' : 'explicit-proxy',
+    checks: { runtime, oauth, reviewer },
+    probe,
+  }
+  process.stdout.write(json ? `${JSON.stringify(report)}\n` : [
+    `Codex Connect ${report.version}: hidden approval-review capability probe`,
+    'Scope: one synthetic no-op; no command is executed and no approval integration is enabled.',
+    `Model: ${report.model}; network: ${report.network}; probe: ${report.probe.state}`,
+    ...Object.entries(report.checks).map(([id, value]) => `${id}: ${value.status} (${value.reason})\n  ${value.action}`),
+    '',
+  ].join('\n'))
+  const primary = [runtime, oauth, reviewer]
+  return primary.some(value => value.status === 'rejected') ? 1 : primary.some(value => value.status === 'unknown') ? 2 : 0
+}

--- a/src/auto-review-probe.ts
+++ b/src/auto-review-probe.ts
@@ -1,0 +1,174 @@
+/** Fixed, standalone probe for the hidden Codex approval reviewer. */
+
+import { Agent, ProxyAgent, fetch } from 'undici'
+import type { Dispatcher } from 'undici'
+import { OPENAI_CODEX_BASE_URL } from './search.ts'
+
+/** Hidden reviewer route selected by the first-party Codex catalog. */
+export const CODEX_AUTO_REVIEW_MODEL = 'codex-auto-review'
+
+/** Only allowlisted observations leave the network reader. */
+export type AutoReviewProbeOutcome = 'completed' | 'http-rejected' | 'transient' | 'incomplete' | 'timeout' | 'cancelled' | 'network-error'
+
+/** No model output, response id, header, or upstream error text is retained. */
+export interface AutoReviewProbeEvidence {
+  outcome: AutoReviewProbeOutcome
+  httpStatus?: number
+}
+
+/** Fully resolved request; credentials remain private to this call. */
+export interface AutoReviewProbeRequest {
+  access: string
+  accountId: string
+  proxyUrl: string | undefined
+  timeoutMs: number
+  signal?: AbortSignal
+}
+
+/** A response-reading limit, not a model output-token setting. */
+const MAX_PROBE_RESPONSE_BYTES = 64 * 1024
+
+const instructions = 'This is a capability diagnostic. Do not call tools or execute any action. Return strict JSON for the supplied synthetic approval request. For this fixed low-risk no-op, return {"outcome":"allow"}.'
+const input = 'Synthetic approval request only; nothing will be executed. Planned action JSON: {"type":"diagnostic-no-op","sideEffects":false}'
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function assessment(text: string): boolean {
+  let value: unknown
+  try {
+    value = JSON.parse(text)
+  } catch {
+    return false
+  }
+  if (!record(value)) return false
+  const keys = Object.keys(value)
+  if (keys.some(key => !['risk_level', 'user_authorization', 'outcome', 'rationale'].includes(key))) return false
+  if (!['allow', 'deny'].includes(String(value['outcome']))) return false
+  if (value['risk_level'] !== undefined && !['low', 'medium', 'high', 'critical'].includes(String(value['risk_level']))) return false
+  if (value['user_authorization'] !== undefined && !['unknown', 'low', 'medium', 'high'].includes(String(value['user_authorization']))) return false
+  return value['rationale'] === undefined || typeof value['rationale'] === 'string'
+}
+
+function completedResponse(value: unknown): boolean {
+  if (!record(value) || value['status'] !== 'completed' || value['model'] !== CODEX_AUTO_REVIEW_MODEL || !Array.isArray(value['output'])) return false
+  const texts = value['output'].flatMap(item => record(item) && item['type'] === 'message' && item['role'] === 'assistant' && Array.isArray(item['content'])
+    ? item['content'].flatMap(part => record(part) && part['type'] === 'output_text' && typeof part['text'] === 'string' ? [part['text']] : [])
+    : [])
+  return texts.length === 1 && assessment(texts[0]!)
+}
+
+/** Inspect complete SSE frames and accept exactly one matching terminal response. */
+function completedStream(text: string): boolean {
+  let completed = false
+  let data: string[] = []
+  for (const line of text.split(/\r\n|\r|\n/u)) {
+    if (line === '') {
+      if (data.length === 0) continue
+      const payload = data.join('\n')
+      data = []
+      if (payload === '[DONE]') continue
+      let event: unknown
+      try {
+        event = JSON.parse(payload)
+      } catch {
+        return false
+      }
+      if (!record(event) || event['type'] === 'error' || event['type'] === 'response.failed' || event['type'] === 'response.incomplete') return false
+      if (event['type'] === 'response.completed' || event['type'] === 'response.done') {
+        if (completed || !completedResponse(event['response'])) return false
+        completed = true
+      }
+    } else if (line.startsWith('data:')) {
+      data.push(line.slice(5).replace(/^ /u, ''))
+    }
+  }
+  return completed && data.length === 0
+}
+
+/**
+ * Send one secret-free synthetic approval to the hidden reviewer model.
+ * The result is evidence only and never authorizes or executes an action.
+ * @param request - OAuth credential, explicit network policy, deadline, and optional cancellation.
+ * @param createDispatcher - owned connection factory; tests use an offline dispatcher.
+ * @returns bounded evidence without model-generated or provider error text.
+ */
+export async function probeCodexAutoReview(
+  request: AutoReviewProbeRequest,
+  createDispatcher: (proxyUrl: string | undefined) => Dispatcher = proxyUrl => proxyUrl === undefined ? new Agent() : new ProxyAgent(proxyUrl),
+): Promise<AutoReviewProbeEvidence> {
+  const dispatcher = createDispatcher(request.proxyUrl)
+  const controller = new AbortController()
+  let timedOut = false
+  let cancelled = request.signal?.aborted ?? false
+  const cancel = (): void => {
+    cancelled = true
+    controller.abort()
+  }
+  request.signal?.addEventListener('abort', cancel, { once: true })
+  if (cancelled) controller.abort()
+  const timer = setTimeout(() => {
+    timedOut = true
+    controller.abort()
+  }, request.timeoutMs)
+  let httpStatus: number | undefined
+  try {
+    const response = await fetch(`${OPENAI_CODEX_BASE_URL}/responses`, {
+      dispatcher,
+      method: 'POST',
+      redirect: 'manual',
+      signal: controller.signal,
+      headers: {
+        authorization: `Bearer ${request.access}`,
+        'chatgpt-account-id': request.accountId,
+        'content-type': 'application/json',
+        accept: 'text/event-stream',
+        originator: 'deepseek-harness',
+      },
+      body: JSON.stringify({
+        model: CODEX_AUTO_REVIEW_MODEL,
+        instructions,
+        input: [{ role: 'user', content: [{ type: 'input_text', text: input }] }],
+        stream: true,
+        store: false,
+      }),
+    })
+    httpStatus = response.status
+    if (!response.ok) {
+      await response.body?.cancel()
+      return { outcome: [400, 401, 403, 404, 405, 422].includes(httpStatus) ? 'http-rejected' : 'transient', httpStatus }
+    }
+    if (httpStatus !== 200 || !response.headers.get('content-type')?.toLowerCase().startsWith('text/event-stream') || response.body === null) {
+      await response.body?.cancel()
+      return { outcome: 'incomplete', httpStatus }
+    }
+    const reader = response.body.getReader()
+    const chunks: Uint8Array[] = []
+    let size = 0
+    try {
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) break
+        size += value.byteLength
+        if (size > MAX_PROBE_RESPONSE_BYTES) {
+          await reader.cancel()
+          return { outcome: 'incomplete', httpStatus }
+        }
+        chunks.push(value)
+      }
+    } finally {
+      reader.releaseLock()
+    }
+    const text = new TextDecoder('utf-8', { fatal: true }).decode(Buffer.concat(chunks))
+    return { outcome: completedStream(text) ? 'completed' : 'incomplete', httpStatus }
+  } catch {
+    // Network, decoding, and cancellation errors can contain credentials or response text.
+    const outcome = cancelled ? 'cancelled' : timedOut ? 'timeout' : 'network-error'
+    return { outcome, ...httpStatus === undefined ? {} : { httpStatus } }
+  } finally {
+    clearTimeout(timer)
+    request.signal?.removeEventListener('abort', cancel)
+    await dispatcher.destroy()
+  }
+}

--- a/src/auto-review-probe.ts
+++ b/src/auto-review-probe.ts
@@ -56,10 +56,10 @@ function assessment(text: string): boolean {
   if (!record(value)) return false
   const keys = Object.keys(value)
   if (keys.some(key => !['risk_level', 'user_authorization', 'outcome', 'rationale'].includes(key))) return false
+  if (!['low', 'medium', 'high', 'critical'].includes(String(value['risk_level']))) return false
+  if (!['unknown', 'low', 'medium', 'high'].includes(String(value['user_authorization']))) return false
   if (!['allow', 'deny'].includes(String(value['outcome']))) return false
-  if (value['risk_level'] !== undefined && !['low', 'medium', 'high', 'critical'].includes(String(value['risk_level']))) return false
-  if (value['user_authorization'] !== undefined && !['unknown', 'low', 'medium', 'high'].includes(String(value['user_authorization']))) return false
-  return value['rationale'] === undefined || typeof value['rationale'] === 'string'
+  return typeof value['rationale'] === 'string'
 }
 
 function completedResponse(value: unknown): string[] | undefined {

--- a/src/auto-review-probe.ts
+++ b/src/auto-review-probe.ts
@@ -28,8 +28,19 @@ export interface AutoReviewProbeRequest {
 /** A response-reading limit, not a model output-token setting. */
 const MAX_PROBE_RESPONSE_BYTES = 64 * 1024
 
-const instructions = 'This is a capability diagnostic. Do not call tools or execute any action. Return strict JSON for the supplied synthetic approval request. For this fixed low-risk no-op, return {"outcome":"allow"}.'
+const instructions = 'This is a capability diagnostic. Do not call tools or execute any action. Return one strict JSON assessment for the supplied synthetic approval request, including risk_level, user_authorization, outcome, and rationale.'
 const input = 'Synthetic approval request only; nothing will be executed. Planned action JSON: {"type":"diagnostic-no-op","sideEffects":false}'
+const assessmentSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    risk_level: { type: 'string', enum: ['low', 'medium', 'high', 'critical'] },
+    user_authorization: { type: 'string', enum: ['unknown', 'low', 'medium', 'high'] },
+    outcome: { type: 'string', enum: ['allow', 'deny'] },
+    rationale: { type: 'string' },
+  },
+  required: ['risk_level', 'user_authorization', 'outcome', 'rationale'],
+} as const
 
 function record(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -51,17 +62,18 @@ function assessment(text: string): boolean {
   return value['rationale'] === undefined || typeof value['rationale'] === 'string'
 }
 
-function completedResponse(value: unknown): boolean {
-  if (!record(value) || value['status'] !== 'completed' || value['model'] !== CODEX_AUTO_REVIEW_MODEL || !Array.isArray(value['output'])) return false
-  const texts = value['output'].flatMap(item => record(item) && item['type'] === 'message' && item['role'] === 'assistant' && Array.isArray(item['content'])
+function completedResponse(value: unknown): string[] | undefined {
+  if (!record(value) || value['status'] !== 'completed' || typeof value['model'] !== 'string' || !Array.isArray(value['output'])) return undefined
+  return value['output'].flatMap(item => record(item) && item['type'] === 'message' && item['role'] === 'assistant' && Array.isArray(item['content'])
     ? item['content'].flatMap(part => record(part) && part['type'] === 'output_text' && typeof part['text'] === 'string' ? [part['text']] : [])
     : [])
-  return texts.length === 1 && assessment(texts[0]!)
 }
 
 /** Inspect complete SSE frames and accept exactly one matching terminal response. */
 function completedStream(text: string): boolean {
   let completed = false
+  let terminalTexts: string[] | undefined
+  const streamedTexts: string[] = []
   let data: string[] = []
   for (const line of text.split(/\r\n|\r|\n/u)) {
     if (line === '') {
@@ -76,15 +88,22 @@ function completedStream(text: string): boolean {
         return false
       }
       if (!record(event) || event['type'] === 'error' || event['type'] === 'response.failed' || event['type'] === 'response.incomplete') return false
+      if (event['type'] === 'response.output_text.done') {
+        if (typeof event['text'] !== 'string') return false
+        streamedTexts.push(event['text'])
+      }
       if (event['type'] === 'response.completed' || event['type'] === 'response.done') {
-        if (completed || !completedResponse(event['response'])) return false
+        terminalTexts = completedResponse(event['response'])
+        if (completed || terminalTexts === undefined) return false
         completed = true
       }
     } else if (line.startsWith('data:')) {
       data.push(line.slice(5).replace(/^ /u, ''))
     }
   }
-  return completed && data.length === 0
+  if (!completed || data.length !== 0) return false
+  const texts = terminalTexts!.length > 0 ? terminalTexts! : streamedTexts
+  return texts.length === 1 && assessment(texts[0]!)
 }
 
 /**
@@ -130,6 +149,14 @@ export async function probeCodexAutoReview(
         model: CODEX_AUTO_REVIEW_MODEL,
         instructions,
         input: [{ role: 'user', content: [{ type: 'input_text', text: input }] }],
+        text: {
+          format: {
+            type: 'json_schema',
+            name: 'codex_auto_review_assessment',
+            strict: true,
+            schema: assessmentSchema,
+          },
+        },
         stream: true,
         store: false,
       }),
@@ -139,7 +166,8 @@ export async function probeCodexAutoReview(
       await response.body?.cancel()
       return { outcome: [400, 401, 403, 404, 405, 422].includes(httpStatus) ? 'http-rejected' : 'transient', httpStatus }
     }
-    if (httpStatus !== 200 || !response.headers.get('content-type')?.toLowerCase().startsWith('text/event-stream') || response.body === null) {
+    const contentType = response.headers.get('content-type')
+    if (httpStatus !== 200 || (contentType !== null && !contentType.toLowerCase().startsWith('text/event-stream')) || response.body === null) {
       await response.body?.cancel()
       return { outcome: 'incomplete', httpStatus }
     }

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -17,6 +17,7 @@ import {
 import { CODEX_CONNECT_VERSION } from './doctor.ts'
 import { normalizeTrustedOrigin, OpenAICodexTrustedOriginsStore } from './trusted-origins.ts'
 import { runCapabilityCommand } from './capability-cli.ts'
+import { runAutoReviewProbeCommand } from './auto-review-cli.ts'
 
 type Action = 'doctor' | 'login' | 'logout' | 'migrate-history' | 'status' | 'trust-origin' | 'trusted-origins' | 'untrust-origin'
 type DiagnosticReport = Awaited<ReturnType<typeof diagnoseOpenAICodex>>
@@ -102,8 +103,10 @@ function printHelp(): void {
     '       dsh-codex-connect trusted-origins [--json]',
     '       dsh-codex-connect untrust-origin <origin>',
     '       dsh-codex-connect capabilities [--model <catalog-id>] [--probe] [--proxy <http(s)-origin>] [--timeout-ms <1..60000>] [--json]',
+    '       dsh-codex-connect auto-review-probe [--proxy <http(s)-origin>] [--timeout-ms <1..60000>] [--json]',
     '',
     '  doctor         inspect secret-free runtime and OAuth file metadata',
+    '  auto-review-probe test the hidden approval reviewer with one synthetic no-op',
     '  login          sign in with a separate ChatGPT OAuth session',
     '  logout         remove the dsh credential without changing ~/.codex',
     '  migrate-history find or repair Alpha 4.10 private search events (dry-run by default)',
@@ -112,7 +115,7 @@ function printHelp(): void {
     '  trusted-origins list the currently allowed browser origins',
     '  untrust-origin remove one exact browser origin from the allowlist',
     '  --device-code  use headless device-code login (login only)',
-    '  --json         emit one JSON document (doctor/status/trusted-origins/migrate-history)',
+    '  --json         emit one JSON document (doctor/status/capabilities/auto-review-probe/trusted-origins/migrate-history)',
     '',
   ].join('\n'))
 }
@@ -156,6 +159,7 @@ export async function run(argv: readonly string[]): Promise<number> {
   }
   const [rawAction, ...flags] = argv
   if (rawAction === 'capabilities') return runCapabilityCommand(flags)
+  if (rawAction === 'auto-review-probe') return runAutoReviewProbeCommand(flags)
   const actions: readonly Action[] = ['doctor', 'login', 'logout', 'migrate-history', 'status', 'trust-origin', 'trusted-origins', 'untrust-origin']
   if (!actions.includes(rawAction as Action)) {
     process.stderr.write(`dsh-codex-connect: expected doctor, login, logout, migrate-history, status, trust-origin, trusted-origins, or untrust-origin; got ${JSON.stringify(rawAction)}\n`)

--- a/tests/auto-review-cli.spec.ts
+++ b/tests/auto-review-cli.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest'
+import { runAutoReviewProbeCommand } from '../src/auto-review-cli.ts'
+import type { AutoReviewProbeDependencies } from '../src/auto-review-cli.ts'
+import { evaluateCompatibility } from '../src/compatibility.ts'
+
+const secret = 'private-access'
+
+function fixture(): AutoReviewProbeDependencies {
+  return {
+    diagnose: async () => ({
+      package: 'dsh-codex-connect', version: '0.1.0-alpha.4.22', node: 'v22.19.0',
+      credentialFile: { path: '/private/credential.json', state: 'owner-only', mode: '600' },
+      capabilities: { modelProvider: true, search: false, imageTool: false, imageGeneration: false, changesHarnessDefaultModel: false, changesHarnessSearchRoute: false },
+      providerConflict: false, hints: [],
+      compatibility: evaluateCompatibility({ nodeVersion: 'v22.19.0', packageVersions: {
+        '@deepseek-ai/dsh-llm': '0.1.2-alpha.2', '@deepseek-ai/dsh-llm-pi-ai': '0.1.2-alpha.2', '@earendil-works/pi-ai': '0.84.4',
+      } }),
+    }),
+    credentials: { read: async () => ({ type: 'oauth', access: secret, refresh: 'private-refresh', accountId: 'private-account', expires: 10_000 }) },
+    probe: async () => ({ outcome: 'completed', httpStatus: 200 }),
+    now: () => 1000,
+  }
+}
+
+describe('auto-review capability command', () => {
+  it('reports only allowlisted evidence for the fixed reviewer route', async () => {
+    let output = ''
+    vi.spyOn(process.stdout, 'write').mockImplementation(chunk => { output += String(chunk); return true })
+    expect(await runAutoReviewProbeCommand(['--json'], fixture())).toBe(0)
+    expect(JSON.parse(output)).toMatchObject({
+      scope: 'auto-review-route-only', model: 'codex-auto-review', probe: { state: 'fresh', httpStatus: 200 },
+      checks: { runtime: { status: 'supported' }, oauth: { status: 'supported' }, reviewer: { status: 'supported' } },
+    })
+    expect(output).not.toContain('private-')
+  })
+
+  it.each([
+    [{ outcome: 'http-rejected', httpStatus: 404 }, 1, 'rejected'],
+    [{ outcome: 'incomplete', httpStatus: 200 }, 2, 'unknown'],
+    [{ outcome: 'timeout' }, 2, 'unknown'],
+    [{ outcome: 'cancelled' }, 2, 'unknown'],
+  ] as const)('fails closed for %j', async (evidence, code, status) => {
+    const deps = fixture()
+    deps.probe = async () => evidence
+    let output = ''
+    vi.spyOn(process.stdout, 'write').mockImplementation(chunk => { output += String(chunk); return true })
+    expect(await runAutoReviewProbeCommand(['--json'], deps)).toBe(code)
+    expect(JSON.parse(output).checks.reviewer.status).toBe(status)
+  })
+
+  it('turns an unexpected transport throw into unknown evidence without leaking it', async () => {
+    const deps = fixture()
+    deps.probe = async () => { throw new Error('private-transport-error') }
+    let output = ''
+    vi.spyOn(process.stdout, 'write').mockImplementation(chunk => { output += String(chunk); return true })
+    expect(await runAutoReviewProbeCommand(['--json'], deps)).toBe(2)
+    expect(JSON.parse(output).checks.reviewer).toMatchObject({ status: 'unknown', reason: 'network-or-stream-error' })
+    expect(output).not.toContain('private-')
+  })
+
+  it.each([
+    ['--timeout-ms', '0'], ['--timeout-ms', '60001'], ['--proxy', 'https://user:private-password@example.test'], ['--json', '--json'], ['--model', 'private-model'],
+  ])('rejects unsafe or unknown flags without echoing values: %j', async (...args) => {
+    let output = ''
+    vi.spyOn(process.stderr, 'write').mockImplementation(chunk => { output += String(chunk); return true })
+    expect(await runAutoReviewProbeCommand(args, fixture())).toBe(2)
+    expect(output).toContain('Usage:')
+    expect(output).not.toContain('private-')
+  })
+})

--- a/tests/auto-review-probe.spec.ts
+++ b/tests/auto-review-probe.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+import { MockAgent } from 'undici'
+import { CODEX_AUTO_REVIEW_MODEL, probeCodexAutoReview } from '../src/auto-review-probe.ts'
+import type { AutoReviewProbeRequest } from '../src/auto-review-probe.ts'
+
+const request: AutoReviewProbeRequest = { access: 'private-access', accountId: 'private-account', proxyUrl: undefined, timeoutMs: 1000 }
+const response = (text: string, model = CODEX_AUTO_REVIEW_MODEL) => ({
+  type: 'response.completed',
+  response: {
+    status: 'completed', model,
+    output: [{ type: 'message', role: 'assistant', content: [{ type: 'output_text', text }] }],
+  },
+})
+const sse = (event: unknown) => `data: ${JSON.stringify(event)}\n\n`
+
+class OfflineProbeAgent extends MockAgent {
+  override destroy(): Promise<void> { return this.close() }
+}
+
+function fixture(status: number, body: string, headers = { 'content-type': 'text/event-stream' }) {
+  const agent = new OfflineProbeAgent()
+  agent.disableNetConnect()
+  agent.get('https://chatgpt.com').intercept({
+    path: '/backend-api/codex/responses', method: 'POST',
+    body: raw => {
+      const payload = JSON.parse(raw) as Record<string, unknown>
+      expect(payload).toMatchObject({ model: CODEX_AUTO_REVIEW_MODEL, stream: true, store: false })
+      expect(JSON.stringify(payload)).toContain('diagnostic-no-op')
+      expect(JSON.stringify(payload)).not.toContain('private-')
+      return true
+    },
+  }).reply(status, body, { headers })
+  return agent
+}
+
+describe('hidden approval reviewer probe', () => {
+  it('accepts one structured assessment and disposes its dispatcher', async () => {
+    const agent = fixture(200, sse(response('{"outcome":"allow"}')))
+    const destroy = vi.spyOn(agent, 'destroy')
+    expect(await probeCodexAutoReview(request, () => agent)).toEqual({ outcome: 'completed', httpStatus: 200 })
+    expect(destroy).toHaveBeenCalledOnce()
+    agent.assertNoPendingInterceptors()
+  })
+
+  it.each([
+    response('allow'),
+    response('{"outcome":"maybe"}'),
+    response('{"outcome":"allow","secret":"private-output"}'),
+    response('{"outcome":"allow"}', 'gpt-5.6-sol'),
+    { type: 'response.completed', response: { status: 'completed', model: CODEX_AUTO_REVIEW_MODEL, output: [] } },
+  ])('keeps malformed or mismatched completion unknown %#', async terminal => {
+    const agent = fixture(200, sse(terminal))
+    expect(await probeCodexAutoReview(request, () => agent)).toEqual({ outcome: 'incomplete', httpStatus: 200 })
+  })
+
+  it.each([400, 401, 403, 404, 405, 422])('reports HTTP %i without retaining the error body', async status => {
+    const agent = fixture(status, JSON.stringify({ error: 'private-access private-account' }))
+    expect(await probeCodexAutoReview(request, () => agent)).toEqual({ outcome: 'http-rejected', httpStatus: status })
+  })
+
+  it('distinguishes caller cancellation from timeout', async () => {
+    const cancelAgent = fixture(200, sse(response('{"outcome":"allow"}')))
+    const cancel = new AbortController()
+    cancel.abort()
+    expect((await probeCodexAutoReview({ ...request, signal: cancel.signal }, () => cancelAgent)).outcome).toBe('cancelled')
+
+    const timeoutAgent = new OfflineProbeAgent()
+    timeoutAgent.disableNetConnect()
+    timeoutAgent.get('https://chatgpt.com').intercept({ path: '/backend-api/codex/responses', method: 'POST' }).reply(200, sse(response('{"outcome":"allow"}'))).delay(100)
+    expect((await probeCodexAutoReview({ ...request, timeoutMs: 5 }, () => timeoutAgent)).outcome).toBe('timeout')
+  })
+})

--- a/tests/auto-review-probe.spec.ts
+++ b/tests/auto-review-probe.spec.ts
@@ -12,12 +12,13 @@ const response = (text: string, model = CODEX_AUTO_REVIEW_MODEL) => ({
   },
 })
 const sse = (event: unknown) => `data: ${JSON.stringify(event)}\n\n`
+const streamedAssessment = (text: string) => sse({ type: 'response.output_text.done', text })
 
 class OfflineProbeAgent extends MockAgent {
   override destroy(): Promise<void> { return this.close() }
 }
 
-function fixture(status: number, body: string, headers = { 'content-type': 'text/event-stream' }) {
+function fixture(status: number, body: string, headers: Record<string, string> = { 'content-type': 'text/event-stream' }) {
   const agent = new OfflineProbeAgent()
   agent.disableNetConnect()
   agent.get('https://chatgpt.com').intercept({
@@ -25,6 +26,20 @@ function fixture(status: number, body: string, headers = { 'content-type': 'text
     body: raw => {
       const payload = JSON.parse(raw) as Record<string, unknown>
       expect(payload).toMatchObject({ model: CODEX_AUTO_REVIEW_MODEL, stream: true, store: false })
+      expect(payload).toMatchObject({
+        text: {
+          format: {
+            type: 'json_schema',
+            name: 'codex_auto_review_assessment',
+            strict: true,
+            schema: {
+              type: 'object',
+              additionalProperties: false,
+              required: ['risk_level', 'user_authorization', 'outcome', 'rationale'],
+            },
+          },
+        },
+      })
       expect(JSON.stringify(payload)).toContain('diagnostic-no-op')
       expect(JSON.stringify(payload)).not.toContain('private-')
       return true
@@ -42,11 +57,17 @@ describe('hidden approval reviewer probe', () => {
     agent.assertNoPendingInterceptors()
   })
 
+  it('accepts the live OAuth stream shape and resolved backing model', async () => {
+    const terminal = { type: 'response.completed', response: { status: 'completed', model: 'gpt-5.6-luna', output: [] } }
+    const agent = fixture(200, streamedAssessment('{"risk_level":"low","user_authorization":"high","outcome":"allow","rationale":"Synthetic no-op."}') + sse(terminal), {})
+    expect(await probeCodexAutoReview(request, () => agent)).toEqual({ outcome: 'completed', httpStatus: 200 })
+  })
+
   it.each([
     response('allow'),
     response('{"outcome":"maybe"}'),
     response('{"outcome":"allow","secret":"private-output"}'),
-    response('{"outcome":"allow"}', 'gpt-5.6-sol'),
+    { type: 'response.completed', response: { status: 'completed', model: null, output: response('{"outcome":"allow"}').response.output } },
     { type: 'response.completed', response: { status: 'completed', model: CODEX_AUTO_REVIEW_MODEL, output: [] } },
   ])('keeps malformed or mismatched completion unknown %#', async terminal => {
     const agent = fixture(200, sse(terminal))

--- a/tests/auto-review-probe.spec.ts
+++ b/tests/auto-review-probe.spec.ts
@@ -50,7 +50,7 @@ function fixture(status: number, body: string, headers: Record<string, string> =
 
 describe('hidden approval reviewer probe', () => {
   it('accepts one structured assessment and disposes its dispatcher', async () => {
-    const agent = fixture(200, sse(response('{"outcome":"allow"}')))
+    const agent = fixture(200, sse(response('{"risk_level":"low","user_authorization":"high","outcome":"allow","rationale":"Synthetic no-op."}')))
     const destroy = vi.spyOn(agent, 'destroy')
     expect(await probeCodexAutoReview(request, () => agent)).toEqual({ outcome: 'completed', httpStatus: 200 })
     expect(destroy).toHaveBeenCalledOnce()
@@ -65,6 +65,8 @@ describe('hidden approval reviewer probe', () => {
 
   it.each([
     response('allow'),
+    response('{"outcome":"allow"}'),
+    response('{"risk_level":"low","user_authorization":"high","outcome":"allow"}'),
     response('{"outcome":"maybe"}'),
     response('{"outcome":"allow","secret":"private-output"}'),
     { type: 'response.completed', response: { status: 'completed', model: null, output: response('{"outcome":"allow"}').response.output } },

--- a/tests/capability-cli.spec.ts
+++ b/tests/capability-cli.spec.ts
@@ -35,6 +35,16 @@ describe('assembled capability CLI', () => {
     expect(output).not.toContain(root)
   })
 
+  it('uses the real reviewer command to stay offline when signed out', async () => {
+    root = await mkdtemp(join(tmpdir(), 'codex-capabilities-'))
+    vi.stubEnv('DSH_HOME', root)
+    let output = ''
+    vi.spyOn(process.stdout, 'write').mockImplementation(chunk => { output += String(chunk); return true })
+    expect(await run(['auto-review-probe', '--json'])).toBe(1)
+    expect(JSON.parse(output)).toMatchObject({ scope: 'auto-review-route-only', probe: { state: 'skipped' }, checks: { oauth: { status: 'rejected' }, reviewer: { status: 'unknown' } } })
+    expect(output).not.toContain(root)
+  })
+
   it.each([
     ['--probe'], ['--model'], ['--timeout-ms', '0'], ['--timeout-ms', '60001'],
     ['--proxy', 'https://user:private-password@example.test'], ['--json', '--json'], ['--token', 'private-access'],

--- a/tests/capability-docs.spec.ts
+++ b/tests/capability-docs.spec.ts
@@ -10,7 +10,7 @@ describe('capability documentation', () => {
       const text = bytes.toString('utf8')
       const hash = createHash('sha1').update(`blob ${bytes.length}\0`).update(bytes).digest('hex')
       expect(pairing).toContain(`${path}: ${hash}`)
-      for (const term of ['capabilities --model gpt-5.6-sol --json', 'capabilities --model gpt-5.6-sol --probe --json', '--timeout-ms <1..60000>', '--proxy <http(s)-origin>', 'supported', 'rejected', 'unknown', '64 KiB']) expect(text).toContain(term)
+      for (const term of ['capabilities --model gpt-5.6-sol --json', 'capabilities --model gpt-5.6-sol --probe --json', 'auto-review-probe --json', '--timeout-ms <1..60000>', '--proxy <http(s)-origin>', 'supported', 'rejected', 'unknown', '64 KiB']) expect(text).toContain(term)
     }
   })
 })


### PR DESCRIPTION
## Summary

- add an opt-in `auto-review-probe` command for the hidden `codex-auto-review` route
- send only one fixed synthetic no-op and require the complete documented approval-review JSON fields
- keep model output, credentials, account ids, response ids, headers, paths, and upstream errors out of the report
- document the evidence boundary in English and Chinese

## Safety boundary

This PR does not add a selectable model, execute a command, enable automatic approval, change DSH policy, or integrate with the DSH approval path. Timeouts, cancellation, malformed output, incomplete streams, rate limits, transport exceptions, and unexpected responses remain unknown evidence. Explicit HTTP rejection remains rejected evidence.

## Validation

- `pnpm run check`
  - 53 test files and 438 tests passed
  - typecheck, lint, build, built CLI proxy check, compatibility check, and package check passed
  - 39 packed files validated
- live test-profile `auto-review-probe --json`
  - exit 0
  - `runtime`, `oauth`, and `reviewer` reported `supported`
  - HTTP 200; the report retained no credentials or model output
- `git diff --check`

## Scope after the probe

This PR completes the route-capability gate for #84. It does not enable automatic approval. A separate opt-in integration must resolve the exact `tool/call` through DSH's immutable session events, preserve DSH policy precedence and human-answerer ordering, and delegate every missing, malformed, cancelled, timed-out, or transport-failed review to the next answerer.

Closes no issue.
