### PR TITLE
fix: authorize session remote in client slots

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -5045,6 +5045,7 @@ window.__ModuleLoader__.load({
 			"locale",
 			"connection",
 			"remote",
+			"remote.session",
 			"settingsScope",
 			"sessions"
 		];

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -46,7 +46,7 @@ declare module '@deepseek-ai/dsh-client-ui-slots' {
 /** Stable browser-plugin name. */
 export const name = 'dsh-codex-connect-client'
 /** Client services required by the Plugin configuration contribution. */
-export const inject = ['slots', 'locale', 'connection', 'remote', 'settingsScope', 'sessions']
+export const inject = ['slots', 'locale', 'connection', 'remote', 'remote.session', 'settingsScope', 'sessions']
 
 /** Register account copy and the OpenAI Codex card under Plugin configuration. */
 export function apply(ctx: ClientContext): void {

--- a/tests/browser/client-injection.browser.client.spec.tsx
+++ b/tests/browser/client-injection.browser.client.spec.tsx
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Context, Service } from '@deepseek-ai/cordis'
+import { apply, inject } from '../../src/client/index.tsx'
+
+type SlotEntry = {
+  name: string
+  inject?: (sessionId: string) => unknown
+}
+
+let composerRegistration: Promise<void>
+let resolveComposerRegistration: () => void
+let rejectComposerRegistration: (reason: unknown) => void
+
+class RemoteFixture extends Service {
+  constructor(ctx: Context) {
+    super(ctx, 'remote')
+  }
+
+  $on(): () => void {
+    return () => undefined
+  }
+}
+
+class RemoteSessionFixture extends Service {
+  readonly store = { model: 'gpt-5.6-sol' }
+
+  constructor(ctx: Context) {
+    super(ctx, 'remote.session')
+  }
+}
+
+class ModelDirectoriesFixture extends Service {
+  static inject = ['remote', 'remote.session']
+
+  constructor(ctx: Context) {
+    super(ctx, 'modelDirectories')
+  }
+
+  directoryFor(): { store: unknown } {
+    const session = this.ctx.remote.session as unknown as { store: unknown }
+    return { store: session.store }
+  }
+}
+
+class SlotsFixture extends Service {
+  constructor(ctx: Context) {
+    super(ctx, 'slots')
+  }
+
+  inject(_name: string, callback: () => void): void {
+    callback()
+  }
+
+  register(entry: SlotEntry): () => void {
+    if (entry.name === 'conversation.input.right') {
+      try {
+        entry.inject?.('session-1')
+        resolveComposerRegistration()
+      } catch (error: unknown) {
+        rejectComposerRegistration(error)
+      }
+    }
+    return () => undefined
+  }
+}
+
+let context: Context | undefined
+
+afterEach(async () => {
+  vi.unstubAllGlobals()
+  await context?.fiber.dispose()
+  context = undefined
+})
+
+describe('OpenAI Codex client dependency injection', () => {
+  it('keeps the model directory remote session available inside Composer slots', async () => {
+    composerRegistration = new Promise<void>((resolve, reject) => {
+      resolveComposerRegistration = resolve
+      rejectComposerRegistration = reject
+    })
+    vi.stubGlobal('fetch', vi.fn(async () => Response.json({ status: 'signed-out' })))
+    const ctx = new Context()
+    context = ctx
+    await ctx.plugin(RemoteFixture)
+    await ctx.plugin(RemoteSessionFixture)
+    await ctx.plugin(ModelDirectoriesFixture)
+    await ctx.plugin(SlotsFixture)
+    ctx.provide('locale', {
+      register: () => () => undefined,
+      bind: () => (key: string) => key,
+    })
+    ctx.provide('connection', {})
+    ctx.provide('settingsScope', { bind: () => ({}) })
+    ctx.provide('sessions', {})
+
+    await expect(ctx.plugin({ name: 'codex-connect-client-fixture', inject, apply })).resolves.toBeDefined()
+    await expect(composerRegistration).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Problem

Opening a Web session with Codex Connect 0.1.0-alpha.4.22 on DSH 0.1.2-alpha.2 can fail with `cannot get property "remote.session" without inject`.

The Composer contributions call `modelDirectories.directoryFor()`. Cordis traces that service call through the consuming client context, but the Codex Connect client plugin declared `remote` without the nested `remote.session` service that the directory resolver uses.

Fixes #95.

## Scope

- Declare `remote.session` as a required client service.
- Add a Chromium regression test that executes the real Cordis `Context` and `Service` injection path inside the Composer slot.
- Regenerate the published client bundle.

## Validation

- `pnpm install --frozen-lockfile` — exit 0.
- Before the fix, the focused Chromium test failed with `cannot get property "remote.session" without inject` at `src/client/index.tsx:102`.
- `pnpm run check` — exit 0; 53 test files and 438 tests passed; 39 packed files validated.
- `pnpm run test:browser` — exit 0; 5 files and 13 tests passed.
- `pnpm run check:dsh-install` — exit 0.

## Security and privacy

This change grants the existing model-directory call the Cordis dependency it already requires. It adds no new network route, credential access, telemetry, or persisted data.

## Out of scope

- DSH 0.1.2-alpha.3 compatibility (#89).
- Auto-review approvals (#93).
- Release or deployment changes.
