### PR TITLE
fix(checks): remove host-specific environment assumptions

### DIFF
--- a/.github/UPSTREAM_DSH_CANARY.md
+++ b/.github/UPSTREAM_DSH_CANARY.md
@@ -12,6 +12,8 @@ The tracker contains public package versions, the plugin commit, Node.js version
 
 ## Response procedure
 
+Summary redaction recognizes the runtime home directory, Linux root homes, Windows drive paths and UNC paths. Repository and temporary-directory markers take precedence over home-directory redaction. Proxy candidate tests isolate all six uppercase and lowercase HTTP, HTTPS and ALL proxy variables from the invoking environment.
+
 1. Open the canonical candidate tracker and linked workflow run. Record the candidate version, current state, plugin commit, stage, and bounded summary.
 2. Reproduce the exact version with `DSH_VERSION=<reported-version> DSH_UNDECLARED_CANARY_VERSION=1 node scripts/check-dsh-install.mjs` from the reported commit. Stop after two identical failures and investigate the upstream change instead of retrying repeatedly.
 3. Use the reported channel to set urgency. An `alpha` or `next` failure is an early warning; an unsupported `latest` release can affect new DSH installations. Channel names do not establish version ordering, so the canary compares the resolved semantic versions before installation.

--- a/scripts/check-dsh-next-contract.mjs
+++ b/scripts/check-dsh-next-contract.mjs
@@ -153,6 +153,11 @@ assertContract('credential-bearing environment is removed', scrubbedEnvironment.
 const sanitized = sanitizeSummary(`${process.cwd()}/secret\n${process.env.HOME}/private\na.b.c`)
 assertContract('repository paths are redacted', !sanitized.includes(process.cwd()) && sanitized.includes('<repository>'))
 assertContract('home paths are redacted', process.env.HOME === undefined || !sanitized.includes(process.env.HOME))
+for (const localPath of ['/root/private/file', 'C:\\Users\\Fixture User\\private.txt', 'D:/Profiles/fixture/private.txt', '\\\\fixture-host\\share\\private.txt']) {
+  assertContract(`portable path is redacted: ${localPath}`, !sanitizeSummary(localPath).includes(localPath))
+}
+assertContract('nonstandard home paths are redacted', sanitizeSummary('/srv/fixture-user/private/file', '/srv/fixture-user') === '<local-path>')
+assertContract('bare home in a diagnostic is redacted', !sanitizeSummary('/srv/fixture-user: permission denied', '/srv/fixture-user').includes('/srv/fixture-user'))
 
 const compatibilityFailure = version => ({
   status: 'fail',

--- a/scripts/check-dsh-next.mjs
+++ b/scripts/check-dsh-next.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -118,12 +118,16 @@ export function parseRegistryDistTags(output) {
   return distTags
 }
 
-export function sanitizeSummary(value) {
+export function sanitizeSummary(value, homeDirectory = homedir()) {
   const lines = value.trim().split(/\r?\n/u).slice(-12).join('\n')
-  return lines
     .replaceAll(REPO_ROOT, '<repository>')
     .replaceAll(tmpdir(), '<temporary-directory>')
-    .replace(/\/(?:Users|home)\/[^\s:'"]+/gu, '<local-path>')
+  const localHome = homeDirectory.length > 1 ? homeDirectory.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&') : undefined
+  const withoutHome = localHome === undefined ? lines : lines.replace(new RegExp(`${localHome}(?=[\\\\/\\s:'"]|$)[^\\r\\n'"]*`, 'giu'), '<local-path>')
+  return withoutHome
+    .replace(/\/(?:root\b|(?:Users|home)\/[^/\s:'"]+)[^\s:'"]*/gu, '<local-path>')
+    .replace(/\b[A-Za-z]:[\\/][^\r\n'"]+/gu, '<local-path>')
+    .replace(/\\\\[^\r\n'"]+/gu, '<local-path>')
     .replace(/[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/gu, '<redacted-token>')
     .slice(0, MAX_SUMMARY_LENGTH)
 }

--- a/tests/proxy-routes.spec.ts
+++ b/tests/proxy-routes.spec.ts
@@ -61,9 +61,7 @@ afterEach(() => { vi.unstubAllEnvs() })
 
 describe('OpenAI Codex proxy routes', () => {
   it('detects bounded candidates without a settings mutation', async () => {
-    vi.stubEnv('HTTPS_PROXY', '')
-    vi.stubEnv('HTTP_PROXY', '')
-    vi.stubEnv('ALL_PROXY', '')
+    for (const name of ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy', 'ALL_PROXY', 'all_proxy']) vi.stubEnv(name, '')
     const probe = vi.fn(async (proxyUrl: string) => ({
       proxyUrl,
       reachable: proxyUrl.endsWith(':7890'),


### PR DESCRIPTION
## Problem and change

Review F9 identified two host-dependent checks: candidate-route tests inherited lowercase proxy variables, and canary summaries missed root and Windows home paths.

- Isolate all six upper/lowercase proxy environment variables in the candidate test.
- Redact the actual home directory, nonstandard homes, `/root`, Windows drive paths and UNC paths while preserving repository/temporary markers.
- Extend the executed canary contract and document the portability guarantees.

## Validation

The lowercase-proxy invocation failed before the fix; after the fix both route tests passed. Four new path cases failed before the fix. The final canary contract passes 44/44 assertions, including nonstandard and bare home paths.

`pnpm run check`: exit 0, 517 tests in 61 files passed, plus canary/release contracts, lint, types, build, proxy import, CLI, compatibility and pack validation. No external accounts or production configuration were used.

This addresses F9 only. No runtime feature, declared compatibility version, merge, deployment or release is changed.
