### PR TITLE
fix(release): require exact-SHA CI and publish verified artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,6 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [main]
 
 concurrency:
   group: dependency-review-${{ github.event.pull_request.number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,20 @@ on:
         type: string
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
+  actions: read
 
 concurrency:
   group: npm-release
   cancel-in-progress: false
 
 jobs:
-  publish:
+  verify:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment: npm-release
+    outputs:
+      sha256: ${{ steps.pack.outputs.sha256 }}
     steps:
       - name: Check out the selected main commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -53,6 +54,11 @@ jobs:
           test "$(npm --version)" = "11.6.4"
           test "$(node --version)" = "v24.15.0"
           test "$(pnpm --version)" = "10.30.3"
+
+      - name: Require successful CI for the exact main SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/verify-release-ci.mjs
 
       - name: Install dependencies from the lockfile
         run: pnpm --config.minimum-release-age=0 install --frozen-lockfile
@@ -125,13 +131,71 @@ jobs:
       - name: Run complete check before publishing
         run: pnpm run check
 
+      - name: Pack the verified files without lifecycle scripts
+        id: pack
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -z "$(git status --porcelain --untracked-files=all -- lib)"
+          mkdir -p "$RUNNER_TEMP/release"
+          npm pack --ignore-scripts --pack-destination "$RUNNER_TEMP/release"
+          mv "$RUNNER_TEMP/release/"*.tgz "$RUNNER_TEMP/release/release.tgz"
+          echo "sha256=$(sha256sum "$RUNNER_TEMP/release/release.tgz" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload the verified package
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: verified-package-${{ github.sha }}
+          path: ${{ runner.temp }}/release/release.tgz
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    needs: verify
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: npm-release
+    permissions:
+      contents: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Check out release gate code only
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.15.0
+      - name: Pin npm for Trusted Publishing
+        run: npm install --global npm@11.6.4 --no-fund --no-audit --ignore-scripts
+      - name: Recheck exact SHA CI after environment approval
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/verify-release-ci.mjs
+      - name: Download the verified package from this run
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: verified-package-${{ github.sha }}
+          path: ${{ runner.temp }}/release
+      - name: Verify package digest
+        shell: bash
+        env:
+          EXPECTED_SHA256: ${{ needs.verify.outputs.sha256 }}
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_SHA256" =~ ^[a-f0-9]{64}$ ]]
+          echo "$EXPECTED_SHA256  $RUNNER_TEMP/release/release.tgz" | sha256sum --check --strict
+
       - name: Publish alpha through npm Trusted Publishing
         shell: bash
         env:
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          npm publish --tag alpha --provenance
+          npm publish "$RUNNER_TEMP/release/release.tgz" --tag alpha --provenance --ignore-scripts
 
       - name: Verify npm version and alpha dist-tag
         shell: bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,10 +25,7 @@ token and does not promote the `latest` dist-tag.
    `main` branch. Enter the exact package version and type `PUBLISH` in the
    confirmation field.
 
-The workflow installs with the frozen lockfile, runs `pnpm run check` before
-publishing, publishes with `npm publish --tag alpha --provenance` through npm
-Trusted Publishing, retries the npm version and `alpha` dist-tag readback, and
-creates the matching GitHub prerelease. It intentionally does not run
+The workflow requires completed successful main CI for the exact release SHA, including both Node versions, browser UI regression and the Windows contract. Missing, incomplete, skipped or failed jobs block publishing. A read-only job installs the frozen dependencies, runs `pnpm run check`, and uploads a SHA-256-identified tarball. The `npm-release` job rechecks CI after environment approval, verifies the tarball digest, and publishes that artifact with lifecycle scripts disabled. Only this job has contents-write and OIDC permissions; it does not install project dependencies or run tests. It retries the npm version and `alpha` dist-tag readback and creates the matching GitHub prerelease. It intentionally does not run
 `npm dist-tag add` because npm Trusted Publishing does not support that command.
 
 ## Promoting `latest` (short-lived interactive authentication)

--- a/scripts/check-release-workflow.mjs
+++ b/scripts/check-release-workflow.mjs
@@ -81,6 +81,7 @@ assertContract('post-publish version and alpha tag verification is retried',
 assertContract('GitHub prerelease is created from the workflow SHA',
   /gh release create[\s\S]*?--prerelease[\s\S]*?--target "\$GITHUB_SHA"[\s\S]*?--generate-notes/.test(workflow))
 assertContract('workflow never promotes the latest dist-tag', !/npm dist-tag add/.test(workflow))
+assertContract('CI also covers dependent PR bases', /pull_request:\s*\n\s{2}workflow_dispatch:/.test(ciWorkflow))
 assertContract('package check invokes this contract', packageJson.scripts?.['check:release-workflow'] === 'node scripts/check-release-workflow.mjs')
 assertContract('full check includes the release contract', /(?:^|&&)\s*pnpm run check:release-workflow(?:\s|$)/.test(packageJson.scripts?.check ?? ''))
 

--- a/scripts/check-release-workflow.mjs
+++ b/scripts/check-release-workflow.mjs
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
+import './verify-release-ci.test.mjs'
 
 const workflowPath = fileURLToPath(new URL('../.github/workflows/release.yml', import.meta.url))
 const ciWorkflowPath = fileURLToPath(new URL('../.github/workflows/ci.yml', import.meta.url))
@@ -28,12 +29,12 @@ assertContract('release concurrency is configured', /^concurrency:\s*\n/m.test(w
 const permissionBlock = workflow.match(/^permissions:\s*\n((?:^[ \t]+[^\n]*\n?)+)/m)?.[1] ?? ''
 const permissionNames = [...permissionBlock.matchAll(/^\s+([a-z-]+):/gm)].map((match) => match[1])
 assertContract(
-  'permissions are limited to contents write and id-token write',
+  'verification has read-only permissions and no OIDC',
   permissionNames.length === 2 &&
     permissionNames.includes('contents') &&
-    permissionNames.includes('id-token') &&
-    /\bcontents:\s*write\b/.test(permissionBlock) &&
-    /\bid-token:\s*write\b/.test(permissionBlock),
+    permissionNames.includes('actions') &&
+    /\bcontents:\s*read\b/.test(permissionBlock) &&
+    /\bactions:\s*read\b/.test(permissionBlock),
 )
 assertContract('long-lived npm token names are absent', !/\b(?:NPM_TOKEN|NODE_AUTH_TOKEN)\b/i.test(workflow))
 assertContract('all actions are pinned to full commit SHAs', (() => {
@@ -64,10 +65,15 @@ assertContract(
     /GH_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}/.test(releaseValidationEnv),
 )
 
-const publishIndex = workflow.indexOf('npm publish --tag alpha --provenance')
+const publishIndex = workflow.indexOf('npm publish "$RUNNER_TEMP/release/release.tgz" --tag alpha --provenance --ignore-scripts')
 const checkIndex = workflow.indexOf('pnpm run check')
 assertContract('complete check precedes npm publish', checkIndex >= 0 && publishIndex > checkIndex)
 assertContract('publish uses npm OIDC provenance and alpha tag', publishIndex >= 0)
+const publishJob = workflow.split('\n  publish:\n')[1] ?? ''
+assertContract('publish waits for read-only verification', /needs: verify/.test(publishJob))
+assertContract('privileged job does not install project dependencies or run project tests', !/pnpm|npm (?:ci|install)(?! --global)/.test(publishJob))
+assertContract('CI is checked before verification and after approval', (workflow.match(/run: node scripts\/verify-release-ci.mjs/g) ?? []).length === 2)
+assertContract('verified artifact is SHA-bound and digest checked', workflow.includes('verified-package-${{ github.sha }}') && publishJob.includes('needs.verify.outputs.sha256') && publishJob.includes('sha256sum --check --strict'))
 assertContract('post-publish version and alpha tag verification is retried',
   /for attempt in 1 2 3 4 5 6/.test(workflow) &&
   /npm view "\$PACKAGE\@\$VERSION" version/.test(workflow) &&

--- a/scripts/verify-release-ci.mjs
+++ b/scripts/verify-release-ci.mjs
@@ -1,0 +1,36 @@
+import { pathToFileURL } from 'node:url'
+
+const required = ['validate (22.19.0)', 'validate (24.x)', 'browser-ui-regression', 'windows-canary-contract']
+
+/** Fail closed unless the selected main SHA completed every required CI job. */
+export function assertReleaseCI(run, jobs, sha, repository) {
+  if (!/^[a-f0-9]{40}$/.test(sha) || run?.head_sha !== sha || run.head_branch !== 'main'
+    || run.repository?.full_name !== repository || run.path !== '.github/workflows/ci.yml'
+    || !['push', 'workflow_dispatch'].includes(run.event)
+    || run.status !== 'completed' || run.conclusion !== 'success') throw new Error('Release SHA does not have completed successful main CI')
+  if (!Array.isArray(jobs) || jobs.some(job => job.status !== 'completed' || job.conclusion !== 'success')
+    || required.some(name => !jobs.some(job => job.name === name))) throw new Error('Required release CI jobs are missing or unsuccessful')
+}
+
+async function main() {
+  const repository = process.env.GITHUB_REPOSITORY
+  const sha = process.env.GITHUB_SHA
+  if (!repository || !sha || !process.env.GH_TOKEN) throw new Error('Missing release CI identity')
+  const get = async path => {
+    const response = await fetch(`https://api.github.com/repos/${repository}/${path}`, {
+      headers: { authorization: `Bearer ${process.env.GH_TOKEN}`, accept: 'application/vnd.github+json' },
+      signal: AbortSignal.timeout(15_000),
+    })
+    if (!response.ok) throw new Error(`CI API failed: ${response.status}`)
+    return response.json()
+  }
+  const listing = await get(`actions/workflows/ci.yml/runs?head_sha=${sha}&branch=main&per_page=100`)
+  const run = listing.workflow_runs?.[0]
+  if (!run) throw new Error('No main CI run for release SHA')
+  const result = await get(`actions/runs/${run.id}/attempts/${run.run_attempt}/jobs?per_page=100`)
+  if (result.total_count !== result.jobs?.length) throw new Error('Incomplete CI job listing')
+  assertReleaseCI(run, result.jobs, sha, repository)
+  console.log(`Release CI verified: ${sha}, run ${run.id}, attempt ${run.run_attempt}`)
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) await main()

--- a/scripts/verify-release-ci.test.mjs
+++ b/scripts/verify-release-ci.test.mjs
@@ -1,0 +1,17 @@
+import { strict as assert } from 'node:assert'
+import { assertReleaseCI } from './verify-release-ci.mjs'
+
+const sha = 'a'.repeat(40)
+const repository = 'fixture/project'
+const run = { head_sha: sha, head_branch: 'main', repository: { full_name: repository }, path: '.github/workflows/ci.yml', event: 'push', status: 'completed', conclusion: 'success' }
+const jobs = ['validate (22.19.0)', 'validate (24.x)', 'browser-ui-regression', 'windows-canary-contract'].map(name => ({ name, status: 'completed', conclusion: 'success' }))
+assert.doesNotThrow(() => assertReleaseCI(run, jobs, sha, repository))
+for (const change of [{ head_sha: 'b'.repeat(40) }, { status: 'in_progress' }, { conclusion: 'failure' }, { head_branch: 'other' }, { event: 'pull_request' }, { path: 'other.yml' }, { repository: { full_name: 'other/repo' } }]) {
+  assert.throws(() => assertReleaseCI({ ...run, ...change }, jobs, sha, repository))
+}
+for (const conclusion of ['failure', 'skipped', 'cancelled']) {
+  assert.throws(() => assertReleaseCI(run, jobs.map(job => job.name === 'browser-ui-regression' ? { ...job, conclusion } : job), sha, repository))
+}
+assert.throws(() => assertReleaseCI(run, jobs.filter(job => job.name !== 'browser-ui-regression'), sha, repository))
+assert.throws(() => assertReleaseCI(run, jobs.map(job => ({ ...job, status: 'in_progress' })), sha, repository))
+console.log('Release CI decision: 13 assertions passed')


### PR DESCRIPTION
## Problem

R2: release verification and dependency lifecycle execution shared the privileged publishing job, and publishing did not require browser CI for the exact selected commit.

## Changes

- Require successful main CI for the exact release SHA, including Node 22/24, browser regression and Windows contracts; reject missing, incomplete, skipped, wrong-SHA and failed results.
- Separate read-only installation/check/pack from the environment-gated publisher. Recheck CI after approval, verify the uploaded tarball SHA-256, and publish that artifact with lifecycle scripts disabled.
- Preserve manual PUBLISH confirmation, alpha-only publishing, availability checks, OIDC provenance and readback. No npm token or latest-tag change.
- Update the release runbook and executed workflow contract.
- Run CI and dependency review for dependent PR bases too, so native stacks retain required checks at every layer.

## Validation

`pnpm run check`: exit 0, 517 tests / 61 files; 13 executable CI decision assertions and 34 workflow assertions pass. The CI verifier also passed a read-only API check against current main SHA `3fa16b1ad9cc443121bbc73872ac296c9e29a57b` and CI run `34011442829`.

This PR does not dispatch the publishing workflow. A real OIDC publish is intentionally not tested; publication remains separately authorized after combined runtime acceptance.
