### PR TITLE
docs: recommend the published Alpha 4.30 pair

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Installation Runbook for CLI Agents
 
-Alpha 4.29 is verified with DSH `0.1.2-rc.1` and its declared pi-ai range `^0.84.2`.
+Alpha 4.30 is verified with DSH `0.1.2-rc.1` and its declared pi-ai range `^0.84.2`.
 
 Install `dsh-codex-connect` into one requested DeepSeek Harness profile without changing its current default model, search route, global configuration, or OAuth state.
 
@@ -23,14 +23,14 @@ Check `dsh --version` before changing the requested profile. Use `dsh --help` to
 | `0.1.0-rc.7` | `0.1.0-alpha.4.14` |
 | `0.1.1-rc.2` | `0.1.0-alpha.4.21` |
 | `0.1.2-alpha.2` | `0.1.0-alpha.4.23` |
-| `0.1.2-rc.1` | `0.1.0-alpha.4.29` |
+| `0.1.2-rc.1` | `0.1.0-alpha.4.30` |
 | `0.1.2-alpha.5` | `0.1.0-alpha.4.25` |
 
 If your exact DSH version is unknown or not listed, stop and verify the combination before installing. Do not blindly install `dsh-codex-connect@alpha`: `alpha` is a moving tag, not a compatibility guarantee. Do not infer support for newer DSH versions from these rows.
 
-Alpha 4.29's verified contract is DSH plugin API packages `0.1.2-rc.1`, `@earendil-works/pi-ai` `^0.84.2`, and Node.js `^22.19.0 || >=24.0.0`. Alpha 4.25 remains the verified choice for DSH `0.1.2-alpha.5`, Alpha 4.23 remains the verified choice for DSH `0.1.2-alpha.2`, Alpha 4.21 remains the verified choice for DSH `0.1.1-rc.2`, and staying on DSH `0.1.0-rc.7` means selecting Alpha 4.14. Upgrading DSH is a separate decision: upgrade the DSH API packages and pi-ai together, then rerun `dsh-codex-connect doctor --json` and `pnpm --silent run check:compatibility` for the selected combination.
+Alpha 4.30's verified contract is DSH plugin API packages `0.1.2-rc.1`, `@earendil-works/pi-ai` `^0.84.2`, and Node.js `^22.19.0 || >=24.0.0`. Alpha 4.25 remains the verified choice for DSH `0.1.2-alpha.5`, Alpha 4.23 remains the verified choice for DSH `0.1.2-alpha.2`, Alpha 4.21 remains the verified choice for DSH `0.1.1-rc.2`, and staying on DSH `0.1.0-rc.7` means selecting Alpha 4.14. Upgrading DSH is a separate decision: upgrade the DSH API packages and pi-ai together, then rerun `dsh-codex-connect doctor --json` and `pnpm --silent run check:compatibility` for the selected combination.
 
-The Alpha 4.29 row reflects a fresh isolated installation and runtime probe. Historical rows remain the repository's existing verification record. This guidance does not change upstream DSH behavior or resolve [Issue #64](https://github.com/franksong2702/dsh-codex-connect/issues/64).
+The Alpha 4.30 row reflects a fresh isolated installation and runtime probe. Historical rows remain the repository's existing verification record. This guidance does not change upstream DSH behavior or resolve [Issue #64](https://github.com/franksong2702/dsh-codex-connect/issues/64).
 
 ### Install the selected version and validate
 
@@ -53,10 +53,10 @@ The Alpha 4.29 row reflects a fresh isolated installation and runtime probe. His
    dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.23
    ```
 
-   For DSH `0.1.2-rc.1`, use Alpha 4.29:
+   For DSH `0.1.2-rc.1`, use Alpha 4.30:
 
    ```sh
-   dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.29
+   dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.30
    ```
 
    For DSH `0.1.2-alpha.5`, use Alpha 4.25:
@@ -65,7 +65,7 @@ The Alpha 4.29 row reflects a fresh isolated installation and runtime probe. His
    dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.25
    ```
 
-   If npm is unavailable after the matching GitHub prerelease is created, use `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.21'` only for the DSH `0.1.1-rc.2` combination, `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.23'` only for the DSH `0.1.2-alpha.2` combination, `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.25'` only for the DSH `0.1.2-alpha.5` combination, or `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.29'` only for the DSH `0.1.2-rc.1` combination.
+   If npm is unavailable after the matching GitHub prerelease is created, use `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.21'` only for the DSH `0.1.1-rc.2` combination, `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.23'` only for the DSH `0.1.2-alpha.2` combination, `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.25'` only for the DSH `0.1.2-alpha.5` combination, or `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.30'` only for the DSH `0.1.2-rc.1` combination.
 
 3. Run `dsh web --help` once to compose the installed profile without starting the server. DSH `0.1.2-rc.1` prepares profile plugin dependency fallback during this step.
 4. Run `dsh --profile web --dump-config` and require exactly one `llm-openai-codex` row loading `dsh-codex-connect`.

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   git hash-object README.md docs/README.zh.md
-README.md: a46589829b432cfcb97af069f7d7a7b3080e42af
-docs/README.zh.md: c42807c90ad4fcc4a4850d1228cfd6330b2bc184
+README.md: 0c847a8b55a88a09732220e0a99f7e06ef7fc993
+docs/README.zh.md: 4a6481f7ded3057d0cd362253b695e25a82df624

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This guide describes the published pairing below. Check `dsh --version` first; f
 
 | Requirement | Verified pairing |
 |---|---|
-| Codex Connect | `0.1.0-alpha.4.29` |
+| Codex Connect | `0.1.0-alpha.4.30` |
 | DeepSeek Harness | `0.1.2-rc.1` |
 | Node.js | `^22.19.0 \|\| >=24.0.0` |
 | Account | ChatGPT OAuth with access to the requested Codex model; availability is decided by OpenAI |
@@ -24,7 +24,7 @@ This guide describes the published pairing below. Check `dsh --version` first; f
 ### 1. Install
 
 ```sh
-dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.29
+dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.30
 dsh web
 ```
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -16,7 +16,7 @@ Codex Connect 为标准 Harness agent loop 添加 `openai-codex` 模型提供方
 
 | 要求 | 已验证组合 |
 |---|---|
-| Codex Connect | `0.1.0-alpha.4.29` |
+| Codex Connect | `0.1.0-alpha.4.30` |
 | DeepSeek Harness | `0.1.2-rc.1` |
 | Node.js | `^22.19.0 \|\| >=24.0.0` |
 | 账户 | 通过 ChatGPT OAuth 使用所请求的 Codex 模型；可用性由 OpenAI 决定 |
@@ -24,7 +24,7 @@ Codex Connect 为标准 Harness agent loop 添加 `openai-codex` 模型提供方
 ### 1. 安装
 
 ```sh
-dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.29
+dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.30
 dsh web
 ```
 

--- a/tests/install-version-guidance.spec.ts
+++ b/tests/install-version-guidance.spec.ts
@@ -14,7 +14,7 @@ describe('installation version guidance', () => {
     ['0.1.1-rc.2', '0.1.0-alpha.4.21'],
     ['0.1.2-alpha.2', '0.1.0-alpha.4.23'],
     ['0.1.2-alpha.5', '0.1.0-alpha.4.25'],
-    ['0.1.2-rc.1', '0.1.0-alpha.4.29'],
+    ['0.1.2-rc.1', '0.1.0-alpha.4.30'],
   ])('selects the recorded DSH %s / Codex Connect %s pair before installation', (dsh, plugin) => {
     expect(firstInstall).toBeGreaterThan(0)
     expect(compatibility.pluginVersions).toContainEqual(expect.objectContaining({
@@ -39,6 +39,6 @@ describe('installation version guidance', () => {
     expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.21/iu)
     expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.23/iu)
     expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.25/iu)
-    expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.29/iu)
+    expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.30/iu)
   })
 })


### PR DESCRIPTION
## Published installation recommendation

Update the English/Chinese README and INSTALL.md from the previously confirmed Alpha 4.29 recommendation to Alpha 4.30 with DSH 0.1.2-rc.1. Preserve all historical DSH pairings and exact GitHub fallback guidance. Refresh the bilingual consistency record and installation guidance assertions.

This is the post-publication documentation step in RELEASING.md, not another package release or a `latest` promotion. The immutable npm package may retain the preceding recommendation in its bundled README.

Publication evidence: [Alpha 4.30 release](https://github.com/franksong2702/dsh-codex-connect/releases/tag/v0.1.0-alpha.4.30) and [protected publish workflow](https://github.com/franksong2702/dsh-codex-connect/actions/runs/34087963781). npm version/tag and Git tag commit were independently checked before opening this PR.

Validation: `pnpm install --frozen-lockfile`, `pnpm run check` (615 tests in 76 files, including documentation and installation guidance, plus typecheck/build/pack), and `git diff --check` passed. No runtime code, dependency, version, or account changes.
