### PR TITLE
docs: recommend published alpha 4.31 pairing

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Installation Runbook for CLI Agents
 
-Alpha 4.30 is verified with DSH `0.1.2-rc.1` and its declared pi-ai range `^0.84.2`.
+Alpha 4.31 is verified with DSH `0.1.2-rc.1` and its declared pi-ai range `^0.84.2`.
 
 Install `dsh-codex-connect` into one requested DeepSeek Harness profile without changing its current default model, search route, global configuration, or OAuth state.
 
@@ -23,14 +23,14 @@ Check `dsh --version` before changing the requested profile. Use `dsh --help` to
 | `0.1.0-rc.7` | `0.1.0-alpha.4.14` |
 | `0.1.1-rc.2` | `0.1.0-alpha.4.21` |
 | `0.1.2-alpha.2` | `0.1.0-alpha.4.23` |
-| `0.1.2-rc.1` | `0.1.0-alpha.4.30` |
+| `0.1.2-rc.1` | `0.1.0-alpha.4.31` |
 | `0.1.2-alpha.5` | `0.1.0-alpha.4.25` |
 
 If your exact DSH version is unknown or not listed, stop and verify the combination before installing. Do not blindly install `dsh-codex-connect@alpha`: `alpha` is a moving tag, not a compatibility guarantee. Do not infer support for newer DSH versions from these rows.
 
-Alpha 4.30's verified contract is DSH plugin API packages `0.1.2-rc.1`, `@earendil-works/pi-ai` `^0.84.2`, and Node.js `^22.19.0 || >=24.0.0`. Alpha 4.25 remains the verified choice for DSH `0.1.2-alpha.5`, Alpha 4.23 remains the verified choice for DSH `0.1.2-alpha.2`, Alpha 4.21 remains the verified choice for DSH `0.1.1-rc.2`, and staying on DSH `0.1.0-rc.7` means selecting Alpha 4.14. Upgrading DSH is a separate decision: upgrade the DSH API packages and pi-ai together, then rerun `dsh-codex-connect doctor --json` and `pnpm --silent run check:compatibility` for the selected combination.
+Alpha 4.31's verified contract is DSH plugin API packages `0.1.2-rc.1`, `@earendil-works/pi-ai` `^0.84.2`, and Node.js `^22.19.0 || >=24.0.0`. Alpha 4.25 remains the verified choice for DSH `0.1.2-alpha.5`, Alpha 4.23 remains the verified choice for DSH `0.1.2-alpha.2`, Alpha 4.21 remains the verified choice for DSH `0.1.1-rc.2`, and staying on DSH `0.1.0-rc.7` means selecting Alpha 4.14. Upgrading DSH is a separate decision: upgrade the DSH API packages and pi-ai together, then rerun `dsh-codex-connect doctor --json` and `pnpm --silent run check:compatibility` for the selected combination.
 
-The Alpha 4.30 row reflects a fresh isolated installation and runtime probe. Historical rows remain the repository's existing verification record. This guidance does not change upstream DSH behavior or resolve [Issue #64](https://github.com/franksong2702/dsh-codex-connect/issues/64).
+The Alpha 4.31 row reflects a fresh isolated installation and runtime probe. Historical rows remain the repository's existing verification record. This guidance does not change upstream DSH behavior or resolve [Issue #64](https://github.com/franksong2702/dsh-codex-connect/issues/64).
 
 ### Install the selected version and validate
 
@@ -53,10 +53,10 @@ The Alpha 4.30 row reflects a fresh isolated installation and runtime probe. His
    dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.23
    ```
 
-   For DSH `0.1.2-rc.1`, use Alpha 4.30:
+   For DSH `0.1.2-rc.1`, use Alpha 4.31:
 
    ```sh
-   dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.30
+   dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.31
    ```
 
    For DSH `0.1.2-alpha.5`, use Alpha 4.25:
@@ -65,7 +65,7 @@ The Alpha 4.30 row reflects a fresh isolated installation and runtime probe. His
    dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.25
    ```
 
-   If npm is unavailable after the matching GitHub prerelease is created, use `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.21'` only for the DSH `0.1.1-rc.2` combination, `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.23'` only for the DSH `0.1.2-alpha.2` combination, `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.25'` only for the DSH `0.1.2-alpha.5` combination, or `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.30'` only for the DSH `0.1.2-rc.1` combination.
+   If npm is unavailable after the matching GitHub prerelease is created, use `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.21'` only for the DSH `0.1.1-rc.2` combination, `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.23'` only for the DSH `0.1.2-alpha.2` combination, `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.25'` only for the DSH `0.1.2-alpha.5` combination, or `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.31'` only for the DSH `0.1.2-rc.1` combination.
 
 3. Run `dsh web --help` once to compose the installed profile without starting the server. DSH `0.1.2-rc.1` prepares profile plugin dependency fallback during this step.
 4. Run `dsh --profile web --dump-config` and require exactly one `llm-openai-codex` row loading `dsh-codex-connect`.

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   git hash-object README.md docs/README.zh.md
-README.md: 28dd22380f25f3ed290ba6049fac87e516f6a496
-docs/README.zh.md: 02d800e4b21809eb16bf4d63df3e15022b2caf25
+README.md: b6e0cd43ba39924b3b76068a56bbac40956cd2a5
+docs/README.zh.md: 2a235d6862317486e56897a623ef0ff6389fc61c

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This guide describes the published pairing below. Check `dsh --version` first; f
 
 | Requirement | Verified pairing |
 |---|---|
-| Codex Connect | `0.1.0-alpha.4.30` |
+| Codex Connect | `0.1.0-alpha.4.31` |
 | DeepSeek Harness | `0.1.2-rc.1` |
 | Node.js | `^22.19.0 \|\| >=24.0.0` |
 | Account | ChatGPT OAuth with access to the requested Codex model; availability is decided by OpenAI |
@@ -24,7 +24,7 @@ This guide describes the published pairing below. Check `dsh --version` first; f
 ### 1. Install
 
 ```sh
-dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.30
+dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.31
 dsh web
 ```
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -16,7 +16,7 @@ Codex Connect 为标准 Harness agent loop 添加 `openai-codex` 模型提供方
 
 | 要求 | 已验证组合 |
 |---|---|
-| Codex Connect | `0.1.0-alpha.4.30` |
+| Codex Connect | `0.1.0-alpha.4.31` |
 | DeepSeek Harness | `0.1.2-rc.1` |
 | Node.js | `^22.19.0 \|\| >=24.0.0` |
 | 账户 | 通过 ChatGPT OAuth 使用所请求的 Codex 模型；可用性由 OpenAI 决定 |
@@ -24,7 +24,7 @@ Codex Connect 为标准 Harness agent loop 添加 `openai-codex` 模型提供方
 ### 1. 安装
 
 ```sh
-dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.30
+dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.31
 dsh web
 ```
 

--- a/tests/install-version-guidance.spec.ts
+++ b/tests/install-version-guidance.spec.ts
@@ -14,7 +14,7 @@ describe('installation version guidance', () => {
     ['0.1.1-rc.2', '0.1.0-alpha.4.21'],
     ['0.1.2-alpha.2', '0.1.0-alpha.4.23'],
     ['0.1.2-alpha.5', '0.1.0-alpha.4.25'],
-    ['0.1.2-rc.1', '0.1.0-alpha.4.30'],
+    ['0.1.2-rc.1', '0.1.0-alpha.4.31'],
   ])('selects the recorded DSH %s / Codex Connect %s pair before installation', (dsh, plugin) => {
     expect(firstInstall).toBeGreaterThan(0)
     expect(compatibility.pluginVersions).toContainEqual(expect.objectContaining({
@@ -39,6 +39,6 @@ describe('installation version guidance', () => {
     expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.21/iu)
     expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.23/iu)
     expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.25/iu)
-    expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.30/iu)
+    expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.31/iu)
   })
 })


### PR DESCRIPTION
## Summary

Update the bilingual README and installation guide to the confirmed published `0.1.0-alpha.4.31` / DSH `0.1.2-rc.1` pair, as required by the release runbook. Refresh the bilingual consistency hashes. Preserve all historical DSH version recommendations.

The npm version, alpha tag, Git tag and GitHub prerelease have been independently verified. npm `latest` remains `0.1.0-alpha.4.30`; this documentation update does not promote it.

## Verification

- `pnpm run check`: 624 tests / 78 files; includes metadata, source lint, types, build and package checks.
- `git diff --check`: no whitespace errors.
- The registry tarball was unpacked and compared with the accepted test candidate: no file differences.

Release: https://github.com/franksong2702/dsh-codex-connect/releases/tag/v0.1.0-alpha.4.31

## Scope

Documentation only. No package version, source, generated runtime, dependency, OAuth, profile or npm channel changes. No package republish.
