### PR TITLE
ci: update paired artifact actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
           echo "sha256=$(sha256sum "$RUNNER_TEMP/release/release.tgz" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
 
       - name: Upload the verified package
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: verified-package-${{ github.sha }}
           path: ${{ runner.temp }}/release/release.tgz
@@ -176,7 +176,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: node scripts/verify-release-ci.mjs
       - name: Download the verified package from this run
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: verified-package-${{ github.sha }}
           path: ${{ runner.temp }}/release


### PR DESCRIPTION
## Summary

- Update the paired artifact handoff Actions in the alpha-release workflow: `upload-artifact` to v7.0.1 and `download-artifact` to v8.0.1.
- Retain immutable full-SHA pins, the SHA-bound artifact name, and the publish-job digest verification.

## Verification

- `pnpm run check` — passed.
- `pnpm run test:browser` — 7 files / 24 tests passed.

No release workflow was dispatched and no package was published.
