### PR TITLE
docs: recommend published alpha 4.32 pairing

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Installation Runbook for CLI Agents
 
-Alpha 4.31 is verified with DSH `0.1.2-rc.1` and its declared pi-ai range `^0.84.2`.
+Alpha 4.32 is verified with DSH `0.1.2-rc.1` and its declared pi-ai range `^0.84.2`.
 
 Install `dsh-codex-connect` into one requested DeepSeek Harness profile without changing its current default model, search route, global configuration, or OAuth state.
 
@@ -23,14 +23,14 @@ Check `dsh --version` before changing the requested profile. Use `dsh --help` to
 | `0.1.0-rc.7` | `0.1.0-alpha.4.14` |
 | `0.1.1-rc.2` | `0.1.0-alpha.4.21` |
 | `0.1.2-alpha.2` | `0.1.0-alpha.4.23` |
-| `0.1.2-rc.1` | `0.1.0-alpha.4.31` |
+| `0.1.2-rc.1` | `0.1.0-alpha.4.32` |
 | `0.1.2-alpha.5` | `0.1.0-alpha.4.25` |
 
 If your exact DSH version is unknown or not listed, stop and verify the combination before installing. Do not blindly install `dsh-codex-connect@alpha`: `alpha` is a moving tag, not a compatibility guarantee. Do not infer support for newer DSH versions from these rows.
 
-Alpha 4.31's verified contract is DSH plugin API packages `0.1.2-rc.1`, `@earendil-works/pi-ai` `^0.84.2`, and Node.js `^22.19.0 || >=24.0.0`. Alpha 4.25 remains the verified choice for DSH `0.1.2-alpha.5`, Alpha 4.23 remains the verified choice for DSH `0.1.2-alpha.2`, Alpha 4.21 remains the verified choice for DSH `0.1.1-rc.2`, and staying on DSH `0.1.0-rc.7` means selecting Alpha 4.14. Upgrading DSH is a separate decision: upgrade the DSH API packages and pi-ai together, then rerun `dsh-codex-connect doctor --json` and `pnpm --silent run check:compatibility` for the selected combination.
+Alpha 4.32's verified contract is DSH plugin API packages `0.1.2-rc.1`, `@earendil-works/pi-ai` `^0.84.2`, and Node.js `^22.19.0 || >=24.0.0`. Alpha 4.25 remains the verified choice for DSH `0.1.2-alpha.5`, Alpha 4.23 remains the verified choice for DSH `0.1.2-alpha.2`, Alpha 4.21 remains the verified choice for DSH `0.1.1-rc.2`, and staying on DSH `0.1.0-rc.7` means selecting Alpha 4.14. Upgrading DSH is a separate decision: upgrade the DSH API packages and pi-ai together, then rerun `dsh-codex-connect doctor --json` and `pnpm --silent run check:compatibility` for the selected combination.
 
-The Alpha 4.31 row reflects a fresh isolated installation and runtime probe. Historical rows remain the repository's existing verification record. This guidance does not change upstream DSH behavior or resolve [Issue #64](https://github.com/franksong2702/dsh-codex-connect/issues/64).
+The Alpha 4.32 row reflects a fresh isolated installation and runtime probe. Historical rows remain the repository's existing verification record. This guidance does not change upstream DSH behavior or resolve [Issue #64](https://github.com/franksong2702/dsh-codex-connect/issues/64).
 
 ### Install the selected version and validate
 
@@ -53,10 +53,10 @@ The Alpha 4.31 row reflects a fresh isolated installation and runtime probe. His
    dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.23
    ```
 
-   For DSH `0.1.2-rc.1`, use Alpha 4.31:
+   For DSH `0.1.2-rc.1`, use Alpha 4.32:
 
    ```sh
-   dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.31
+   dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.32
    ```
 
    For DSH `0.1.2-alpha.5`, use Alpha 4.25:
@@ -65,7 +65,7 @@ The Alpha 4.31 row reflects a fresh isolated installation and runtime probe. His
    dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.25
    ```
 
-   If npm is unavailable after the matching GitHub prerelease is created, use `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.21'` only for the DSH `0.1.1-rc.2` combination, `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.23'` only for the DSH `0.1.2-alpha.2` combination, `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.25'` only for the DSH `0.1.2-alpha.5` combination, or `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.31'` only for the DSH `0.1.2-rc.1` combination.
+   If npm is unavailable after the matching GitHub prerelease is created, use `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.21'` only for the DSH `0.1.1-rc.2` combination, `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.23'` only for the DSH `0.1.2-alpha.2` combination, `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.25'` only for the DSH `0.1.2-alpha.5` combination, or `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.32'` only for the DSH `0.1.2-rc.1` combination.
 
 3. Run `dsh web --help` once to compose the installed profile without starting the server. DSH `0.1.2-rc.1` prepares profile plugin dependency fallback during this step.
 4. Run `dsh --profile web --dump-config` and require exactly one `llm-openai-codex` row loading `dsh-codex-connect`.

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   git hash-object README.md docs/README.zh.md
-README.md: b3d0bdd487da3988c277f9d6ed0cdd0ef3f62023
-docs/README.zh.md: 75b42211584eeaa14dfcc1b2aee451052d3c874f
+README.md: a2b62adb9a1280a012b60b2296c3c1e01af27199
+docs/README.zh.md: 96e6c09313ab1175f29e85e1fcd40acd66b55748

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This guide describes the published pairing below. Check `dsh --version` first; f
 
 | Requirement | Verified pairing |
 |---|---|
-| Codex Connect | `0.1.0-alpha.4.31` |
+| Codex Connect | `0.1.0-alpha.4.32` |
 | DeepSeek Harness | `0.1.2-rc.1` |
 | Node.js | `^22.19.0 \|\| >=24.0.0` |
 | Account | ChatGPT OAuth with access to the requested Codex model; availability is decided by OpenAI |
@@ -24,7 +24,7 @@ This guide describes the published pairing below. Check `dsh --version` first; f
 ### 1. Install
 
 ```sh
-dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.31
+dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.32
 dsh web
 ```
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -16,7 +16,7 @@ Codex Connect 为标准 Harness agent loop 添加 `openai-codex` 模型提供方
 
 | 要求 | 已验证组合 |
 |---|---|
-| Codex Connect | `0.1.0-alpha.4.31` |
+| Codex Connect | `0.1.0-alpha.4.32` |
 | DeepSeek Harness | `0.1.2-rc.1` |
 | Node.js | `^22.19.0 \|\| >=24.0.0` |
 | 账户 | 通过 ChatGPT OAuth 使用所请求的 Codex 模型；可用性由 OpenAI 决定 |
@@ -24,7 +24,7 @@ Codex Connect 为标准 Harness agent loop 添加 `openai-codex` 模型提供方
 ### 1. 安装
 
 ```sh
-dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.31
+dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.32
 dsh web
 ```
 

--- a/tests/install-version-guidance.spec.ts
+++ b/tests/install-version-guidance.spec.ts
@@ -14,7 +14,7 @@ describe('installation version guidance', () => {
     ['0.1.1-rc.2', '0.1.0-alpha.4.21'],
     ['0.1.2-alpha.2', '0.1.0-alpha.4.23'],
     ['0.1.2-alpha.5', '0.1.0-alpha.4.25'],
-    ['0.1.2-rc.1', '0.1.0-alpha.4.31'],
+    ['0.1.2-rc.1', '0.1.0-alpha.4.32'],
   ])('selects the recorded DSH %s / Codex Connect %s pair before installation', (dsh, plugin) => {
     expect(firstInstall).toBeGreaterThan(0)
     expect(compatibility.pluginVersions).toContainEqual(expect.objectContaining({
@@ -39,6 +39,6 @@ describe('installation version guidance', () => {
     expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.21/iu)
     expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.23/iu)
     expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.25/iu)
-    expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.31/iu)
+    expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.32/iu)
   })
 })


### PR DESCRIPTION
## Summary

- Recommend the now-published Codex Connect 0.1.0-alpha.4.32 with the verified DSH 0.1.2-rc.1 pairing in both READMEs and INSTALL.md.
- Refresh the bilingual consistency hashes. No runtime, dependency, package version, or channel changes.

## Evidence

- Release workflow 34214546632 succeeded for commit 5f71a9b1cb63b99a3a906c392b253abdabc4dbf6.
- Independent npm readback: version and alpha are 0.1.0-alpha.4.32; latest remains 0.1.0-alpha.4.30.
- GitHub prerelease and Git tag match that exact commit.
- pnpm run lint:metadata: exit 0, 44 release-metadata regression cases passed.
- git diff --check: exit 0; reviewed all four changed files.
- Initial CI exposed two installation-guidance assertions still pinned to 4.31 (634 passed, 2 failed). Updated only those expected versions; pnpm exec vitest run tests/install-version-guidance.spec.ts: exit 0, 7 tests passed. No runtime code changed.

Documentation-only follow-up required by RELEASING.md. The immutable npm artifact is not republished to refresh its README. Full runtime checks were performed on the released candidate; no additional local runtime suite was needed for installation-text changes.
