### PR TITLE
docs: recommend published alpha 4.34 and record release recovery

### DIFF
--- a/.github/ALPHA_434_RELEASE_READINESS.md
+++ b/.github/ALPHA_434_RELEASE_READINESS.md
@@ -28,3 +28,34 @@ Follow [RELEASING.md](../RELEASING.md). Merge this metadata update through the n
 After publication, independently verify npm version and alpha dist-tag, unchanged latest dist-tag, matching Git tag and prerelease, package integrity and extracted contents, and isolated installed-model resolution. Only then update the four public installation recommendation files together and resolve #186 with the exact published installation command and verification scope. The old npm package's embedded README is immutable and must not be republished just to refresh documentation.
 
 Merge, npm publication, documentation updates, and issue closure are separate observable steps. No local DSH deployment, service restart, npm latest promotion, or unrelated feature merge is included.
+
+## Publication and independent readback — 2026-09-11
+
+Release preparation #187 merged as `d3ab2fbc8b297feeb4930a33e75b5b7aace14d8a`. Its tree is identical to the reviewed PR head `71b173f3455fb32f5c28082cf4ca4870d746c561`. [Final main CI 34552166038](https://github.com/franksong2702/dsh-codex-connect/actions/runs/34552166038) passed both configured Node jobs, Chromium regression, Windows canary contracts, and all four exact-host installation matrices. Every matrix still identified artifact `d9ac135f1a77b9b8e882c25b145624597c1213d6dcde970630818cbd2c405f65`.
+
+The earlier [release run 34451145561](https://github.com/franksong2702/dsh-codex-connect/actions/runs/34451145561), started on 2026-09-10 from `06383d29467d9649abc5ee671a9d453e7f0d47a8`, was waiting for its `npm-release` environment approval and occupied the release concurrency group. Its publish job had not executed any steps. It was cancelled as a superseded, unpublished candidate before the new release proceeded.
+
+[Release run 34552519354](https://github.com/franksong2702/dsh-codex-connect/actions/runs/34552519354) verified and published `0.1.0-alpha.4.34` from `d3ab2fbc8b297feeb4930a33e75b5b7aace14d8a` through the existing OIDC workflow and authorized environment approval. Its immediate npm version/alpha readback exhausted six attempts, so the overall workflow remains **failed** and GitHub prerelease creation was skipped. The logs do not establish the exact cache or registry-propagation cause.
+
+Independent registry and npm CLI readback then confirmed:
+
+- `version=0.1.0-alpha.4.34`, `alpha=0.1.0-alpha.4.34`, and unchanged `latest=0.1.0-alpha.4.30`.
+- npm SHA-512 integrity and SHA-1 `2af70739e199afc068582c116a0887d8ad7499bd` verified against the downloaded archive.
+- The npm archive and the workflow's verified artifact are byte-identical, both with SHA-256 `d9ac135f1a77b9b8e882c25b145624597c1213d6dcde970630818cbd2c405f65`. All 62 extracted files are also byte-identical; the packaged runtime contains `modelErrors` and declares all four exact DSH targets.
+- Following RELEASING.md's partial-publication recovery, the [GitHub prerelease](https://github.com/franksong2702/dsh-codex-connect/releases/tag/v0.1.0-alpha.4.34) was created at `2026-09-11T02:05:12Z`. Its Git tag resolves to the original published commit above. npm was not republished, the existing version was not overwritten, and no tag was moved.
+
+## Published-package upgrade regression
+
+An isolated, credential-free macOS fixture installed DSH CLI `0.1.5-rc.1`; the actual model runtime resolved `@deepseek-ai/dsh-llm=0.1.5-rc.2`, `@deepseek-ai/dsh-llm-pi-ai=0.1.5-rc.2`, and pi-ai `0.85.1`. These versions were observed independently, not inferred from the CLI string.
+
+Published Alpha 4.33 reproduced `Cannot read properties of undefined (reading 'get')`. The documented exact-version command then upgraded the existing fixture profile:
+
+```sh
+dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.34
+```
+
+A fresh doctor process reported version 4.34 and compatible runtime dependencies. A fresh installed-runtime process resolved and prepared all eight models and verified provider disposal. Actual model-runtime dependencies, default model, and search route stayed unchanged; all five optional capabilities stayed disabled. Credentials were absent before and after, no live model requests were made, and the temporary fixture was removed. This verifies the published exact-version installation path, not a deployed interactive browser or real-account upgrade.
+
+Earlier fixture attempts were not passes: two incorrectly assumed the runtime version equalled the CLI version, and a moving-alpha update attempt failed in pnpm. The final exact-version test above passed. Those failures do not establish a general defect in `update ...@alpha`, nor is that moving-tag upgrade path claimed as verified by this test. Public recommendations therefore use the verified exact-version command.
+
+The post-publication documentation change updates README.md, docs/README.zh.md, INSTALL.md, and README.i18n.yaml together. It does not republish the immutable npm package to refresh its embedded README. Issue #186 can be resolved for the now-published installation fix; tracker #183 retains its separately outstanding full live-acceptance scope.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Installation Runbook for CLI Agents
 
-Alpha 4.33 is verified with DSH `0.1.2-rc.1` and pi-ai `0.84.4` within `^0.84.2`, and with DSH `0.1.5-alpha.1` and pi-ai `0.85.1`.
+Published Alpha 4.34 is verified with DSH `0.1.2-rc.1` and pi-ai `0.84.4` within `^0.84.2`, and with each exact DSH `0.1.5-alpha.1`, `0.1.5-rc.1`, and `0.1.5-rc.2` model-runtime pairing using pi-ai `0.85.1`.
 
 Install `dsh-codex-connect` into one requested DeepSeek Harness profile without changing its current default model, search route, global configuration, or OAuth state.
 
@@ -16,22 +16,26 @@ Install `dsh-codex-connect` into one requested DeepSeek Harness profile without 
 
 ### Select an exact version before installation
 
-Check `dsh --version` before changing the requested profile. Use `dsh --help` to locate the CLI if needed; from a Harness checkout use `pnpm dsh --version`. Select an exact pair from [verified-compatibility.json](verified-compatibility.json):
+Check `dsh --version` before changing the requested profile. Use `dsh --help` to locate the CLI if needed; from a Harness checkout use `pnpm dsh --version`. The CLI string alone does not identify every installed model-runtime package: a CLI reporting `0.1.5-rc.1` can resolve `0.1.5-rc.2` packages. When the plugin is already installed, also run `dsh plugin --profile web exec dsh-codex-connect doctor --json` and inspect the installed `@deepseek-ai/dsh-llm`, `@deepseek-ai/dsh-llm-pi-ai`, and pi-ai versions. Substitute the requested profile. Select an exact pair from [verified-compatibility.json](verified-compatibility.json):
 
 | Installed DSH version | Codex Connect version to pin |
 | --- | --- |
 | `0.1.0-rc.7` | `0.1.0-alpha.4.14` |
 | `0.1.1-rc.2` | `0.1.0-alpha.4.21` |
 | `0.1.2-alpha.2` | `0.1.0-alpha.4.23` |
-| `0.1.2-rc.1` | `0.1.0-alpha.4.33` |
+| `0.1.2-rc.1` | `0.1.0-alpha.4.34` |
 | `0.1.2-alpha.5` | `0.1.0-alpha.4.25` |
-| `0.1.5-alpha.1` | `0.1.0-alpha.4.33` |
+| `0.1.5-alpha.1` | `0.1.0-alpha.4.34` |
+| `0.1.5-rc.1` | `0.1.0-alpha.4.34` |
+| `0.1.5-rc.2` | `0.1.0-alpha.4.34` |
 
 If your exact DSH version is unknown or not listed, preserve the installed host, report that the combination is unverified, and verify it before making installation changes. A missing record does not prove incompatibility, and the catalog's latest verified DSH version is not the latest upstream release. Do not recommend upgrading or downgrading DSH merely to match a row. Investigate any specific failure and seek verification of the installed combination. Do not blindly install `dsh-codex-connect@alpha`: `alpha` is a moving tag, not a compatibility guarantee. Do not infer support for newer DSH versions from these rows.
 
-Alpha 4.33 requires one consistent DSH plugin API version: `0.1.2-rc.1` with `@earendil-works/pi-ai` `^0.84.2`, or `0.1.5-alpha.1` with pi-ai `0.85.1`; Node.js remains `^22.19.0 || >=24.0.0`. Mixed host versions and other DSH/pi-ai combinations remain unverified. Alpha 4.25 remains the verified choice for DSH `0.1.2-alpha.5`, Alpha 4.23 remains the verified choice for DSH `0.1.2-alpha.2`, Alpha 4.21 remains the verified choice for DSH `0.1.1-rc.2`, and staying on DSH `0.1.0-rc.7` means selecting Alpha 4.14. Changing DSH is a separate operation requiring the user's explicit request; a plugin update request does not authorize it. The repository's `pnpm --silent run check:compatibility` remains a strict development/release dependency gate, not a recommendation to change a user's host.
+Alpha 4.34 requires one consistent DSH plugin API version: `0.1.2-rc.1` with `@earendil-works/pi-ai` `^0.84.2`, or one of `0.1.5-alpha.1`, `0.1.5-rc.1`, and `0.1.5-rc.2` with pi-ai `0.85.1`; Node.js remains `^22.19.0 || >=24.0.0`. Mixed host versions and other DSH/pi-ai combinations remain unverified. Alpha 4.25 remains the verified choice for DSH `0.1.2-alpha.5`, Alpha 4.23 remains the verified choice for DSH `0.1.2-alpha.2`, Alpha 4.21 remains the verified choice for DSH `0.1.1-rc.2`, and staying on DSH `0.1.0-rc.7` means selecting Alpha 4.14. Changing DSH is a separate operation requiring the user's explicit request; a plugin update request does not authorize it. The repository's `pnpm --silent run check:compatibility` remains a strict development/release dependency gate, not a recommendation to change a user's host.
 
-The Alpha 4.33 rows reflect same-artifact isolated installation and runtime checks, bounded real-account calls, and isolated upgrades from Alpha 4.32. Fresh OAuth and manual callback acceptance used the real implementation through a temporary acceptance page. See [.github/ALPHA_433_RELEASE_READINESS.md](https://github.com/franksong2702/dsh-codex-connect/blob/main/.github/ALPHA_433_RELEASE_READINESS.md) for commands and verification limits. Historical rows remain the repository's existing verification record. This guidance does not change upstream DSH behavior or resolve [Issue #64](https://github.com/franksong2702/dsh-codex-connect/issues/64).
+The Alpha 4.34 rows reflect same-artifact isolated installation and model-runtime checks on both configured Node versions, browser regression, Windows canary contracts, and independent verification of the published npm artifact. All eight advertised models resolved and prepared, defaults were unchanged, and provider disposal succeeded. These are not fresh real OAuth, live model/tool/image, or full Windows application acceptance. See [.github/ALPHA_434_RELEASE_READINESS.md](https://github.com/franksong2702/dsh-codex-connect/blob/main/.github/ALPHA_434_RELEASE_READINESS.md) for release recovery, upgrade evidence, and verification limits. Historical rows remain the repository's existing verification record. This guidance does not change upstream DSH behavior or resolve [Issue #64](https://github.com/franksong2702/dsh-codex-connect/issues/64).
+
+Alpha 4.33 omits the `modelErrors` profile field required by RC model packages, producing `Cannot read properties of undefined (reading 'get')`. Alpha 4.34 contains the fix. Reauthorization or repeated model-list retries do not add a missing profile field. Pin the corrected plugin version for a verified host combination; do not delete credentials or change DSH merely to work around this failure. DSH `0.1.5-alpha.2` remains unverified.
 
 ### Install the selected version and validate
 
@@ -54,10 +58,10 @@ The Alpha 4.33 rows reflect same-artifact isolated installation and runtime chec
    dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.23
    ```
 
-   For DSH `0.1.2-rc.1` or `0.1.5-alpha.1`, use Alpha 4.33:
+   For DSH `0.1.2-rc.1`, `0.1.5-alpha.1`, `0.1.5-rc.1`, or `0.1.5-rc.2`, use Alpha 4.34:
 
    ```sh
-   dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.33
+   dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.34
    ```
 
    For DSH `0.1.2-alpha.5`, use Alpha 4.25:
@@ -66,7 +70,7 @@ The Alpha 4.33 rows reflect same-artifact isolated installation and runtime chec
    dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.25
    ```
 
-   If npm is unavailable after the matching GitHub prerelease is created, use `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.21'` only for the DSH `0.1.1-rc.2` combination, `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.23'` only for the DSH `0.1.2-alpha.2` combination, `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.25'` only for the DSH `0.1.2-alpha.5` combination, or `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.33'` only for the DSH `0.1.2-rc.1` or `0.1.5-alpha.1` combinations.
+   If npm is unavailable after the matching GitHub prerelease is created, use `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.21'` only for the DSH `0.1.1-rc.2` combination, `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.23'` only for the DSH `0.1.2-alpha.2` combination, `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.25'` only for the DSH `0.1.2-alpha.5` combination, or `dsh plugin --profile web add 'github:franksong2702/dsh-codex-connect#v0.1.0-alpha.4.34'` only for the DSH `0.1.2-rc.1`, `0.1.5-alpha.1`, `0.1.5-rc.1`, or `0.1.5-rc.2` combinations.
 
 3. Run `dsh web --help` once to compose the installed profile without starting the server. DSH `0.1.2-rc.1` prepares profile plugin dependency fallback during this step.
 4. Run `dsh --profile web --dump-config` and require exactly one `llm-openai-codex` row loading `dsh-codex-connect`.

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   git hash-object README.md docs/README.zh.md
-README.md: abaac5cb3f80c204f01c6b804fff06e649a75298
-docs/README.zh.md: fe1383a7deaeaf355782ee6cf79f296e0f3cbaad
+README.md: cf5ea52f978f456a8d245b5bb9d95d172f16f695
+docs/README.zh.md: da6e0575f8f2171a21aeacf0f78b64cdf0bdf4ef

--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ Codex Connect adds the `openai-codex` model provider to the normal Harness agent
 
 ## Quick start
 
-This guide describes the published pairing below. Check `dsh --version` first; for another DSH version, use [Installation and upgrades](INSTALL.md). A moving npm tag such as `alpha` is not a compatibility guarantee.
+This guide describes the published pairings below. Check `dsh --version` first and use `doctor --json` to inspect the installed model-runtime packages: an rc.1 CLI can resolve rc.2 packages. For other versions, use [Installation and upgrades](INSTALL.md). A moving npm tag such as `alpha` is not a compatibility guarantee.
 
 | Requirement | Verified pairing |
 |---|---|
-| Codex Connect | `0.1.0-alpha.4.33` |
-| DeepSeek Harness | `0.1.2-rc.1` or `0.1.5-alpha.1` |
+| Codex Connect | `0.1.0-alpha.4.34` |
+| DeepSeek Harness | `0.1.2-rc.1`, `0.1.5-alpha.1`, `0.1.5-rc.1`, or `0.1.5-rc.2` |
 | Node.js | `^22.19.0 \|\| >=24.0.0` |
 | Account | ChatGPT OAuth with access to the requested Codex model; availability is decided by OpenAI |
 
 ### 1. Install
 
 ```sh
-dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.33
+dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.34
 dsh web
 ```
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -12,19 +12,19 @@ Codex Connect 为标准 Harness agent loop 添加 `openai-codex` 模型提供方
 
 ## 快速开始
 
-本指南介绍下方已发布的组合。请先运行 `dsh --version`；其他 DSH 版本请查阅[安装与升级](../INSTALL.md)。`alpha` 等会移动的 npm tag 不代表兼容性保证。
+本指南介绍下方已发布的组合。请先运行 `dsh --version`，并用 `doctor --json` 检查实际安装的模型运行库：rc.1 CLI 可能解析到 rc.2 包。其他版本请查阅[安装与升级](../INSTALL.md)。`alpha` 等会移动的 npm tag 不代表兼容性保证。
 
 | 要求 | 已验证组合 |
 |---|---|
-| Codex Connect | `0.1.0-alpha.4.33` |
-| DeepSeek Harness | `0.1.2-rc.1` 或 `0.1.5-alpha.1` |
+| Codex Connect | `0.1.0-alpha.4.34` |
+| DeepSeek Harness | `0.1.2-rc.1`、`0.1.5-alpha.1`、`0.1.5-rc.1` 或 `0.1.5-rc.2` |
 | Node.js | `^22.19.0 \|\| >=24.0.0` |
 | 账户 | 通过 ChatGPT OAuth 使用所请求的 Codex 模型；可用性由 OpenAI 决定 |
 
 ### 1. 安装
 
 ```sh
-dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.33
+dsh plugin --profile web add dsh-codex-connect@0.1.0-alpha.4.34
 dsh web
 ```
 

--- a/tests/install-version-guidance.spec.ts
+++ b/tests/install-version-guidance.spec.ts
@@ -14,8 +14,10 @@ describe('installation version guidance', () => {
     ['0.1.1-rc.2', '0.1.0-alpha.4.21'],
     ['0.1.2-alpha.2', '0.1.0-alpha.4.23'],
     ['0.1.2-alpha.5', '0.1.0-alpha.4.25'],
-    ['0.1.2-rc.1', '0.1.0-alpha.4.33'],
-    ['0.1.5-alpha.1', '0.1.0-alpha.4.33'],
+    ['0.1.2-rc.1', '0.1.0-alpha.4.34'],
+    ['0.1.5-alpha.1', '0.1.0-alpha.4.34'],
+    ['0.1.5-rc.1', '0.1.0-alpha.4.34'],
+    ['0.1.5-rc.2', '0.1.0-alpha.4.34'],
   ])('selects the recorded DSH %s / Codex Connect %s pair before installation', (dsh, plugin) => {
     expect(firstInstall).toBeGreaterThan(0)
     expect(compatibility.pluginVersions).toContainEqual(expect.objectContaining({
@@ -40,6 +42,6 @@ describe('installation version guidance', () => {
     expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.21/iu)
     expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.23/iu)
     expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.25/iu)
-    expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.33/iu)
+    expect(install).toMatch(/npm is unavailable[^\n]*github:franksong2702\/dsh-codex-connect#v0\.1\.0-alpha\.4\.34/iu)
   })
 })


### PR DESCRIPTION
## Summary

Post-publication documentation follow-up to #185 and #187. Alpha `0.1.0-alpha.4.34` now exists on npm and its GitHub prerelease/tag resolve to release commit `d3ab2fbc8b297feeb4930a33e75b5b7aace14d8a`.

- Update README.md, docs/README.zh.md, INSTALL.md, and README.i18n.yaml together to recommend the published exact version for all four verified host pairs.
- Explain why CLI rc.1 can resolve rc.2 model-runtime packages and why the modelErrors fault requires the corrected plugin, not reauthorization.
- Update installation-guidance regression expectations and add rc.1/rc.2 rows.
- Record the superseded waiting release run, successful npm publication followed by failed immediate readback, and recovery of the GitHub prerelease without republishing npm.

No production source, generated library, dependency, workflow, default, or credential changes. This PR does not republish the immutable npm package or move any npm tag.

## Observed evidence

- Final release main CI: https://github.com/franksong2702/dsh-codex-connect/actions/runs/34552166038 — all required jobs and four exact-host installation matrices passed.
- npm alpha=4.34, latest remains 4.30. Published archive and verified release artifact are byte-identical: SHA-256 `d9ac135f1a77b9b8e882c25b145624597c1213d6dcde970630818cbd2c405f65`; all 62 files match and SHA-512/SHA-1 integrity passes.
- Published-package upgrade regression passed in an isolated, keyless fixture: CLI rc.1, actual model runtime rc.2 / pi-ai 0.85.1; 4.33 reproduced undefined.get, exact-version add upgraded to 4.34, doctor became compatible, all 8 models resolved/prepared, provider disposal passed, runtime dependency versions and defaults remained unchanged. No live request or existing-user service modification.
- Local `pnpm run check`: pass after synchronizing installation-version fixture expectations.
- `git diff --check`, changed-path scope, unchanged runtime/dependencies, bilingual blob hashes: pass.

Release workflow 34552519354 remains failed at its immediate npm readback step; it is not presented as green. The actual published artifact and recovered release were independently verified. Earlier failed fixture attempts are recorded in the readiness note rather than claimed as passes. #183's full live-acceptance scope remains outstanding.