### PR TITLE
fix: distinguish declared DSH regressions from new canary candidates

### DIFF
--- a/.github/workflows/upstream-dsh-canary.yml
+++ b/.github/workflows/upstream-dsh-canary.yml
@@ -98,7 +98,7 @@ jobs:
               pluginCommit: context.sha,
             })
             if (tracking === undefined) {
-              core.info('The channel is unchanged, older, or deduplicated; no candidate tracker is needed.')
+              core.info('The declared regression passed, or the channel is older/deduplicated; no new candidate tracker is needed. Full acceptance remains separate.')
               return
             }
             const issues = await github.paginate(github.rest.issues.listForRepo, {

--- a/scripts/canary-multiversion.test.mjs
+++ b/scripts/canary-multiversion.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { classifyCandidateVersion, declaredDshVersions, runCanary } from './check-dsh-next.mjs'
+import { buildCanaryTrackingIssue } from './canary-tracking.mjs'
+
+const compatibility = JSON.parse(await readFile(new URL('../compatibility.json', import.meta.url), 'utf8'))
+const versions = declaredDshVersions(compatibility)
+const baseline = compatibility.dshPluginApi.version
+const metadata = { runUrl: 'https://github.com/franksong2702/dsh-codex-connect/actions/runs/123', pluginCommit: 'a'.repeat(40) }
+assert.deepEqual(declaredDshVersions({ dshPluginApi: { version: baseline } }), [baseline])
+for (const bad of [null, [], [baseline, baseline], ['invalid'], ['0.1.9'], [baseline, null]]) {
+  assert.throws(() => declaredDshVersions({ dshPluginApi: { version: baseline, versions: bad } }))
+}
+assert.throws(() => declaredDshVersions({ dshPluginApi: { version: null, versions } }))
+for (const version of versions) assert.equal(classifyCandidateVersion(version, baseline, versions), 'declared')
+// Holes and future versions never inherit support from a later declared version.
+for (const version of ['0.1.5-alpha.2', '0.1.5-rc.3', '0.1.6', '9.9.9']) {
+  assert.equal(classifyCandidateVersion(version, baseline, versions), 'newer')
+}
+assert.equal(classifyCandidateVersion('0.1.1-rc.2', baseline, versions), 'not-newer')
+
+const root = await mkdtemp(join(tmpdir(), 'canary-multiversion-'))
+let fixtureRuns = 0
+try {
+  async function fixture(version, exitCode = 0, dedupeAgainst = []) {
+    const index = ++fixtureRuns
+    const observedPath = join(root, `observed-${index}.json`)
+    const childPath = join(root, `child-${index}.mjs`)
+    const outputPath = join(root, `report-${index}.json`)
+    await writeFile(childPath, `import { writeFileSync } from 'node:fs';\nwriteFileSync(${JSON.stringify(observedPath)}, JSON.stringify({version: process.env.DSH_VERSION, undeclared: process.env.DSH_UNDECLARED_CANARY_VERSION ?? null}));\nprocess.exitCode = ${exitCode};\n`)
+    const status = await runCanary({
+      channel: 'next', dedupeAgainst, outputPath,
+      resolvedDistTags: { latest: version, next: version, alpha: baseline },
+    }, { candidateCheckPath: childPath })
+    const report = JSON.parse(await readFile(outputPath, 'utf8'))
+    let child
+    try { child = JSON.parse(await readFile(observedPath, 'utf8')) } catch (error) { if (error.code !== 'ENOENT') throw error }
+    assert.deepEqual(report.supportedVersions, versions)
+    assert.equal(report.acceptanceScope, 'not-assessed')
+    return { status, report, child }
+  }
+
+  // Exercise the real child path, not only the pure classification helper.
+  const previous = process.env.DSH_UNDECLARED_CANARY_VERSION
+  process.env.DSH_UNDECLARED_CANARY_VERSION = '1'
+  try {
+    for (const version of versions) {
+      const result = await fixture(version)
+      assert.equal(result.status, 0)
+      assert.equal(result.report.classification, 'declared-compatible')
+      assert.equal(result.report.declaredSupport, true)
+      assert.equal(result.report.stage, 'isolated-install')
+      assert.deepEqual(result.child, { version, undeclared: null })
+      assert.equal(buildCanaryTrackingIssue(result.report, undefined, metadata), undefined)
+    }
+  } finally {
+    if (previous === undefined) delete process.env.DSH_UNDECLARED_CANARY_VERSION
+    else process.env.DSH_UNDECLARED_CANARY_VERSION = previous
+  }
+  const hole = await fixture('0.1.5-alpha.2')
+  assert.equal(hole.report.classification, 'candidate-compatible')
+  assert.equal(hole.report.declaredSupport, false)
+  assert.deepEqual(hole.child, { version: '0.1.5-alpha.2', undeclared: '1' })
+  const tracker = buildCanaryTrackingIssue(hole.report, undefined, metadata)
+  assert.equal(tracker.state, 'passed-needs-full-validation')
+  assert.ok(tracker.body.includes('`0.1.5-rc.2`'))
+  assert.ok(tracker.body.includes('Full user acceptance: not assessed'))
+
+  for (const result of [await fixture('0.1.1-rc.2'), await fixture(versions.at(-1), 0, ['latest'])]) {
+    assert.equal(result.status, 0)
+    assert.equal(result.child, undefined)
+    assert.equal(buildCanaryTrackingIssue(result.report, undefined, metadata), undefined)
+  }
+  const failed = await fixture(versions.at(-1), 1)
+  const repeated = await fixture(versions.at(-1), 1)
+  assert.equal(failed.status, 1)
+  const regression = buildCanaryTrackingIssue(failed.report, repeated.report, metadata)
+  assert.equal(regression.state, 'declared-regression')
+  assert.equal(regression.label, 'bug')
+  assert.equal(regression.marker, `<!-- dsh-canary-regression:${versions.at(-1)} -->`)
+  assert.notEqual(regression.marker, `<!-- dsh-canary:${versions.at(-1)} -->`)
+  assert.ok(regression.title.includes('regression on declared'))
+  const infrastructure = await fixture(versions.at(-1), 2)
+  assert.equal(infrastructure.status, 2)
+  assert.equal(buildCanaryTrackingIssue(failed.report, infrastructure.report, metadata).state, 'infrastructure-blocked')
+  const recovered = await fixture(versions.at(-1))
+  assert.equal(buildCanaryTrackingIssue(failed.report, recovered.report, metadata), undefined)
+  console.log(`canary multi-version regression: ${fixtureRuns} child-routing scenarios passed`)
+} finally {
+  await rm(root, { recursive: true, force: true })
+}

--- a/scripts/canary-tracking.mjs
+++ b/scripts/canary-tracking.mjs
@@ -25,10 +25,15 @@ function trackingState(first, second) {
     && second.status === 'fail'
     && first.classification === 'compatibility'
     && second.classification === 'compatibility'
-  return confirmedCompatibilityFailure ? 'compatibility-failed' : 'infrastructure-blocked'
+  return confirmedCompatibilityFailure
+    ? (final.declaredSupport === true ? 'declared-regression' : 'compatibility-failed')
+    : 'infrastructure-blocked'
 }
 
 function stateExplanation(state, channel, version) {
+  if (state === 'declared-regression') {
+    return `The bounded regression failed twice for already-declared DSH ${version} on ${channel}. Investigate the regression without treating this host as a new support request. Full user acceptance remains a separate record.`
+  }
   if (state === 'passed-needs-full-validation') {
     return `The bounded Codex Connect check passed against \`@deepseek-ai/dsh@${channel}\` version \`${version}\`. Full Web, OAuth, model, tool, image, network, quota, settings, and session validation is still required before compatibility can be declared.`
   }
@@ -49,12 +54,17 @@ export function buildCanaryTrackingIssue(first, second, metadata) {
     }
   }
   const final = second ?? first
+  // A successful declared regression, including a recovered retry, must not
+  // reopen a candidate/full-acceptance issue or falsely certify acceptance.
+  if (final.status === 'pass' && final.classification === 'declared-compatible') return undefined
   const state = trackingState(first, second)
   const version = first.candidateVersion
   const channel = first.channel
-  const marker = `<!-- dsh-canary:${version} -->`
+  const marker = final.declaredSupport === true
+    ? `<!-- dsh-canary-regression:${version} -->`
+    : `<!-- dsh-canary:${version} -->`
   const stateMarker = `<!-- dsh-canary-state:${state}:${channel} -->`
-  const label = state === 'compatibility-failed' ? 'bug' : 'enhancement'
+  const label = ['compatibility-failed', 'declared-regression'].includes(state) ? 'bug' : 'enhancement'
   const pluginCommit = final.pluginCommit ?? metadata.pluginCommit
   const body = [
     marker,
@@ -67,7 +77,10 @@ export function buildCanaryTrackingIssue(first, second, metadata) {
     '',
     `- Candidate DSH version: \`${version}\``,
     `- Current owning channel: \`${channel}\``,
-    `- Declared supported DSH version: \`${final.supportedVersion}\``,
+    `- Declared DSH baseline: \`${final.supportedVersion}\``,
+    `- Declared supported DSH versions: ${(final.supportedVersions ?? [final.supportedVersion]).map(value => `\`${value}\``).join(', ')}`,
+    `- Candidate declared support: ${final.declaredSupport === true ? 'yes' : 'not declared'}`,
+    '- Full user acceptance: not assessed by this automated check',
     `- Candidate stage: \`${final.stage ?? 'unknown'}\``,
     `- Plugin commit: \`${pluginCommit}\``,
     `- Node.js: \`${final.nodeVersion ?? 'unknown'}\``,
@@ -79,7 +92,7 @@ export function buildCanaryTrackingIssue(first, second, metadata) {
     boundedSummary(final),
     '```',
     '',
-    'This tracker is preliminary evidence only. It does not widen the supported version range, edit `verified-compatibility.json`, deploy a profile, merge code, or publish a release. Complete the full test-profile validation before declaring compatibility.',
+    'This tracker is preliminary evidence only. It does not widen the supported version range, edit `verified-compatibility.json`, deploy a profile, merge code, publish a release, or replace the separate full user-acceptance record.',
     '',
     'Umbrella: #108',
     '',
@@ -89,7 +102,7 @@ export function buildCanaryTrackingIssue(first, second, metadata) {
     state,
     marker,
     stateMarker,
-    title: `compatibility: track DSH ${version}`,
+    title: final.declaredSupport === true ? `compatibility: regression on declared DSH ${version}` : `compatibility: track DSH ${version}`,
     body,
     label,
   }

--- a/scripts/check-canary-workflow.mjs
+++ b/scripts/check-canary-workflow.mjs
@@ -164,8 +164,8 @@ assertContract('mismatched retry candidates fail closed', (() => {
     return true
   }
 })())
-assertContract('candidate checker opts into the undeclared-version mode', /DSH_UNDECLARED_CANARY_VERSION:\s*'1'/.test(nextCheck))
-assertContract('only candidates that supersede declared support reach isolated installation', /compareSemanticVersions\(candidateVersion, supportedVersion\) > 0[\s\S]*?versionClassification === 'not-newer'[\s\S]*?const candidateCheck/u.test(nextCheck))
+assertContract('only undeclared candidates opt into warning-tolerant validation', /delete checkEnvironment\.DSH_UNDECLARED_CANARY_VERSION[\s\S]*?if \(!declaredSupport\) checkEnvironment\.DSH_UNDECLARED_CANARY_VERSION = '1'/.test(nextCheck))
+assertContract('declared versions and candidates newer than the baseline reach isolated installation', /compareSemanticVersions\(candidateVersion, supportedVersion\) > 0[\s\S]*?versionClassification === 'not-newer'[\s\S]*?const candidateCheck/u.test(nextCheck))
 assertContract('candidate classification is driven by fail-closed exit codes', /classifyCandidateCheckStatus\(candidateCheck\.status\)/.test(nextCheck) && /error instanceof CompatibilityCheckError \? 1 : 2/.test(installCheck))
 assertContract('registry and candidate subprocesses have explicit timeouts', /REGISTRY_TIMEOUT_MS\s*=\s*60 \* 1000[\s\S]*?CANDIDATE_CHECK_TIMEOUT_MS\s*=\s*25 \* 60 \* 1000/.test(nextCheck) && /timeoutMs:\s*COMMAND_TIMEOUT_MS/.test(installCheck))
 assertContract('candidate subprocesses receive a scrubbed environment', /scrubCanaryEnvironment\(process\.env\)/.test(nextCheck) && /allowUndeclaredCanaryVersion[\s\S]*?scrubCanaryEnvironment\(process\.env\)/.test(installCheck))

--- a/scripts/check-dsh-next-contract.mjs
+++ b/scripts/check-dsh-next-contract.mjs
@@ -26,6 +26,7 @@ import {
   validateDoctorResult,
 } from './check-dsh-install.mjs'
 import { validateRuntimeProjection } from './check-installed-runtime.mjs'
+import './canary-multiversion.test.mjs'
 
 const failures = []
 let assertionCount = 0
@@ -127,7 +128,7 @@ assertContract(
     alpha: '0.1.4-alpha.1',
   }) === undefined,
 )
-assertContract('an exact declared version is unchanged', classifyCandidateVersion('0.1.2-alpha.5', '0.1.2-alpha.5') === 'unchanged')
+assertContract('an exact supported version is declared', classifyCandidateVersion('0.1.2-alpha.5', '0.1.2-alpha.5') === 'declared')
 assertContract('an older stable candidate is not newer than a declared alpha', classifyCandidateVersion('0.1.1-rc.2', '0.1.2-alpha.5') === 'not-newer')
 assertContract(
   'later prereleases and stable releases supersede a declared alpha',

--- a/scripts/check-dsh-next.mjs
+++ b/scripts/check-dsh-next.mjs
@@ -147,8 +147,23 @@ export function duplicateCandidateOwner(channel, dedupeAgainst, distTags) {
   return dedupeAgainst.find(owner => distTags[channel] === distTags[owner])
 }
 
-export function classifyCandidateVersion(candidateVersion, supportedVersion) {
-  if (candidateVersion === supportedVersion) return 'unchanged'
+/** Validate the exact support set; the legacy scalar is a baseline, not the full set. */
+export function declaredDshVersions(compatibility) {
+  const baseline = compatibility?.dshPluginApi?.version
+  const supplied = compatibility?.dshPluginApi?.versions
+  const versions = supplied === undefined ? [baseline] : supplied
+  if (typeof baseline !== 'string' || parseSemanticVersion(baseline) === undefined
+    || !Array.isArray(versions) || versions.length === 0 || versions.length > 64
+    || versions.some(value => typeof value !== 'string' || parseSemanticVersion(value) === undefined)
+    || new Set(versions).size !== versions.length || !versions.includes(baseline)) {
+    throw new Error('compatibility.json has an invalid exact DSH support set')
+  }
+  return [...versions]
+}
+
+export function classifyCandidateVersion(candidateVersion, supportedVersion, supportedVersions = [supportedVersion]) {
+  if (supportedVersions.includes(candidateVersion)) return 'declared'
+  // Comparing only with the maximum would skip holes such as alpha.2.
   return compareSemanticVersions(candidateVersion, supportedVersion) > 0 ? 'newer' : 'not-newer'
 }
 
@@ -226,11 +241,14 @@ async function emitReport(path, report) {
   process.stdout.write(serialized)
 }
 
-function baseReport(supportedVersion, channel) {
+function baseReport(supportedVersion, supportedVersions, channel) {
   return {
     schemaVersion: JSON_SCHEMA_VERSION,
     channel,
     supportedVersion,
+    supportedVersions,
+    declaredSupport: null,
+    acceptanceScope: 'not-assessed',
     candidateVersion: null,
     nodeVersion: process.version,
     pluginCommit: process.env.GITHUB_SHA ?? null,
@@ -266,14 +284,9 @@ export async function runCanary(options, dependencies = {}) {
   }
   const { channel, dedupeAgainst, outputPath, resolvedDistTags } = options
   const compatibility = JSON.parse(await readFile(COMPATIBILITY_FILE, 'utf8'))
-  const supportedVersion = compatibility?.dshPluginApi?.version
-  if (typeof supportedVersion !== 'string' || supportedVersion.length === 0) {
-    throw new Error('compatibility.json has no declared DSH plugin API version')
-  }
-  if (parseSemanticVersion(supportedVersion) === undefined) {
-    throw new Error('compatibility.json has an invalid DSH plugin API version')
-  }
-  const base = baseReport(supportedVersion, channel)
+  const supportedVersions = declaredDshVersions(compatibility)
+  const supportedVersion = compatibility.dshPluginApi.version
+  const base = baseReport(supportedVersion, supportedVersions, channel)
   const resolved = resolvedDistTags === undefined ? await resolveRegistryDistTags() : { distTags: resolvedDistTags }
   if (resolved.distTags === undefined) {
     await emitReport(outputPath, {
@@ -287,6 +300,9 @@ export async function runCanary(options, dependencies = {}) {
   }
   const distTags = resolved.distTags
   const candidateVersion = distTags[channel]
+  const versionClassification = classifyCandidateVersion(candidateVersion, supportedVersion, supportedVersions)
+  const declaredSupport = versionClassification === 'declared'
+  base.declaredSupport = declaredSupport
 
   const duplicateOwner = duplicateCandidateOwner(channel, dedupeAgainst, distTags)
   if (duplicateOwner !== undefined) {
@@ -297,19 +313,6 @@ export async function runCanary(options, dependencies = {}) {
       classification: 'duplicate',
       stage: 'compare-candidate',
       summary: `DSH ${channel} matches ${duplicateOwner} at ${candidateVersion}; the ${duplicateOwner} canary owns this candidate.`,
-    })
-    return 0
-  }
-
-  const versionClassification = classifyCandidateVersion(candidateVersion, supportedVersion)
-  if (versionClassification === 'unchanged') {
-    await emitReport(outputPath, {
-      ...base,
-      candidateVersion,
-      status: 'pass',
-      classification: 'unchanged',
-      stage: 'compare-candidate',
-      summary: `DSH ${channel} remains at the declared supported version ${supportedVersion}.`,
     })
     return 0
   }
@@ -326,12 +329,11 @@ export async function runCanary(options, dependencies = {}) {
     return 0
   }
 
+  const checkEnvironment = { ...scrubCanaryEnvironment(process.env), DSH_VERSION: candidateVersion }
+  delete checkEnvironment.DSH_UNDECLARED_CANARY_VERSION
+  if (!declaredSupport) checkEnvironment.DSH_UNDECLARED_CANARY_VERSION = '1'
   const candidateCheck = await runCommand(process.execPath, [candidateCheckPath], {
-    env: {
-      ...scrubCanaryEnvironment(process.env),
-      DSH_VERSION: candidateVersion,
-      DSH_UNDECLARED_CANARY_VERSION: '1',
-    },
+    env: checkEnvironment,
     timeoutMs: CANDIDATE_CHECK_TIMEOUT_MS,
   })
   if (candidateCheck.status !== 0) {
@@ -352,9 +354,12 @@ export async function runCanary(options, dependencies = {}) {
     ...base,
     candidateVersion,
     status: 'pass',
-    classification: 'candidate-compatible',
+    classification: declaredSupport ? 'declared-compatible' : 'candidate-compatible',
     stage: 'isolated-install',
-    summary: `The isolated ${channel} install check passed with DSH ${candidateVersion}; declared support remains ${supportedVersion}.`,
+    summary: declaredSupport
+      ? `The isolated ${channel} regression passed for declared DSH ${candidateVersion}. Full user acceptance was not assessed by this check.`
+      : `The isolated ${channel} install check passed for undeclared DSH ${candidateVersion}. Declared versions: ${supportedVersions.join(', ')}. Full user acceptance remains separate.`,
+
   })
   return 0
 }


### PR DESCRIPTION
## Summary

Use the exact `dshPluginApi.versions` support set rather than treating its legacy scalar baseline as the only supported host. Every current declared channel still runs the strict isolated runtime regression. Undeclared holes such as 0.1.5-alpha.2 remain candidates even when a later RC is supported; historical channels below the baseline and duplicate channels are skipped.

Reports preserve the legacy baseline field and add the complete exact set, declaration status, and explicit `acceptanceScope: not-assessed`. Successful declared checks (including successful retries) do not create or reopen new-support/full-acceptance trackers. Confirmed declared failures use a separate regression marker so they do not overwrite #183 or other acceptance work.

## Validation

- Frozen install passed without dependency or lockfile changes.
- `pnpm run check` passed: workflow contracts, source tests, typechecks, build, CLI, compatibility and pack checks.
- Added 11 real child-routing fixture scenarios, plus exact-set validation and semantic version hole assertions; exercised by the existing Windows contract job as well.
- `git diff --check` passed. Runtime `src/`, committed `lib/`, package version, published bytes, compatibility declarations, and existing services are unchanged.

No live-account acceptance, npm publication, dist-tag changes, or unrelated feature PRs are included. Full user acceptance remains separate.