### PR TITLE
fix: diagnose npm readback and recover published releases without republishing

### DIFF
--- a/.github/workflows/recover-release.yml
+++ b/.github/workflows/recover-release.yml
@@ -1,0 +1,51 @@
+name: Recover published alpha release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact Alpha version already published on npm
+        required: true
+        type: string
+      original_run_id:
+        description: Original Publish alpha release run ID whose publish step succeeded
+        required: true
+        type: string
+      confirm:
+        description: Type RECOVER to authorize missing GitHub prerelease creation only
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: npm-release
+  cancel-in-progress: false
+
+jobs:
+  recover:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: npm-release
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - name: Check out trusted recovery code only
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.15.0
+      - name: Verify original evidence and complete missing prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          ORIGINAL_RUN_ID: ${{ inputs.original_run_id }}
+          CONFIRM: ${{ inputs.confirm }}
+        run: node scripts/recover-release.mjs --version "$VERSION" --run-id "$ORIGINAL_RUN_ID" --apply

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,32 +198,9 @@ jobs:
           npm publish "$RUNNER_TEMP/release/release.tgz" --tag alpha --provenance --ignore-scripts
 
       - name: Verify npm version and alpha dist-tag
-        shell: bash
         env:
           VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          readonly PACKAGE='dsh-codex-connect'
-          for attempt in 1 2 3 4 5 6; do
-            version_json="$(npm view "$PACKAGE@$VERSION" version --json 2>/dev/null || true)"
-            alpha_json="$(npm view "$PACKAGE" dist-tags.alpha --json 2>/dev/null || true)"
-            if node -e '
-              const [expected, versionRaw, alphaRaw] = process.argv.slice(1)
-              const parse = (raw) => {
-                try { return JSON.parse(raw) }
-                catch { return raw.trim() }
-              }
-              if (parse(versionRaw) !== expected || parse(alphaRaw) !== expected) process.exit(1)
-            ' "$VERSION" "$version_json" "$alpha_json"; then
-              echo "npm published $PACKAGE@$VERSION with alpha=$VERSION."
-              exit 0
-            fi
-            if (( attempt < 6 )); then
-              sleep 10
-            fi
-          done
-          echo "npm did not expose $PACKAGE@$VERSION and dist-tags.alpha=$VERSION after six attempts." >&2
-          exit 1
+        run: node scripts/verify-npm-readback.mjs
 
       - name: Create GitHub prerelease
         shell: bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -64,17 +64,55 @@ npm logout
 The readback must equal `<version>`. After the first stable release,
 `latest` must point only to stable releases.
 
+## npm readback diagnostics
+
+The post-publish check now uses `scripts/verify-npm-readback.mjs`: at most 12
+attempts, ten seconds apart, with parallel bounded version/tag queries to the
+explicit public registry and `--prefer-online`. Each query has a 12-second npm
+fetch timeout, no internal retries, and a 20-second process deadline. Output
+records only exit codes, allowlisted error codes, valid version strings, and
+whether the exact version/alpha pair matched. It never prints raw responses,
+local paths, authorization URLs, or credentials. A mismatch, invalid JSON, and
+query failure remain different observations; none by itself proves propagation
+delay. `--prefer-online` requests fresher metadata but cannot guarantee immediate
+registry visibility. See the [npm configuration reference](https://docs.npmjs.com/cli/v11/using-npm/config/).
+
 ## If npm published but GitHub release creation failed
 
-Do not publish the npm version again. After confirming the npm readback, create
-the missing prerelease from the same commit with GitHub CLI:
+**Do not rerun npm publication.** Use the original release run ID, not the latest
+main commit. First run read-only verification from trusted current main code:
 
 ```sh
-gh release create "v<version>" --repo franksong2702/dsh-codex-connect \
-  --prerelease --target <commit-sha> --generate-notes
+node scripts/recover-release.mjs --version <exact-alpha-version> --run-id <original-release-run-id>
 ```
 
-Use a short-lived `gh` authentication session as required by your local
-environment; never record its OAuth URL or token. If the target Git tag already
-exists, the command attaches the release to that tag; otherwise, stop and
-investigate the commit/tag mismatch before retrying.
+The helper requires the original repository/main/workflow identity, successful
+verification and authorized publish steps, successful exact-SHA main CI, and a
+non-expired verified artifact from that run. It downloads data only, never runs
+the old package, and requires npm metadata, SHA-512 integrity, SHA-1, manifest
+identity, and exact archive bytes to match the original artifact. The original
+SHA must remain on main. Existing tags must resolve to that SHA; conflicting
+or draft/non-prerelease releases stop recovery. Missing or expired evidence
+also stops recovery; rebuilding current main is not a substitute.
+
+To complete a missing prerelease, manually dispatch **Recover published alpha
+release** on main with the same version, original run ID, and `RECOVER`.
+The existing `npm-release` environment approval and shared release concurrency
+apply. This workflow has no OIDC/npm publication permission or package-install
+step. Alternatively, an authorized maintainer can apply the verified result:
+
+```sh
+CONFIRM=RECOVER node scripts/recover-release.mjs --version <exact-alpha-version> --run-id <original-release-run-id> --apply
+```
+
+Apply only creates missing tag/release records and checks their final identity.
+It never moves an existing tag, promotes npm or GitHub latest, or republishes npm.
+An already-complete matching release is a no-op, including on retry. If tag
+creation succeeds but release creation fails, inspect and rerun this recovery
+helper rather than deleting or moving the tag. A later alpha channel does not
+block recovery of the exact historical package and is never rolled back.
+
+The original failed workflow remains historical evidence, not a success claim.
+Record the recovery verification/run alongside it. Do not copy temporary signed
+artifact-download URLs or authentication material into reports. Artifact API
+semantics: [GitHub Actions artifacts](https://docs.github.com/en/rest/actions/artifacts).

--- a/scripts/check-release-workflow.mjs
+++ b/scripts/check-release-workflow.mjs
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import './verify-release-ci.test.mjs'
+import './verify-npm-readback.test.mjs'
+import './recover-release.test.mjs'
 
 const workflowPath = fileURLToPath(new URL('../.github/workflows/release.yml', import.meta.url))
 const ciWorkflowPath = fileURLToPath(new URL('../.github/workflows/ci.yml', import.meta.url))
@@ -74,10 +76,11 @@ assertContract('publish waits for read-only verification', /needs: verify/.test(
 assertContract('privileged job does not install project dependencies or run project tests', !/pnpm|npm (?:ci|install)(?! --global)/.test(publishJob))
 assertContract('CI is checked before verification and after approval', (workflow.match(/run: node scripts\/verify-release-ci.mjs/g) ?? []).length === 2)
 assertContract('verified artifact is SHA-bound and digest checked', workflow.includes('verified-package-${{ github.sha }}') && publishJob.includes('needs.verify.outputs.sha256') && publishJob.includes('sha256sum --check --strict'))
-assertContract('post-publish version and alpha tag verification is retried',
-  /for attempt in 1 2 3 4 5 6/.test(workflow) &&
-  /npm view "\$PACKAGE\@\$VERSION" version/.test(workflow) &&
-  /npm view "\$PACKAGE" dist-tags\.alpha/.test(workflow))
+const readbackSource = readFileSync(new URL('./verify-npm-readback.mjs', import.meta.url), 'utf8')
+assertContract('post-publish readback uses tested bounded online diagnostics',
+  /run: node scripts\/verify-npm-readback.mjs/.test(workflow)
+    && readbackSource.includes('--prefer-online') && readbackSource.includes('NPM_READBACK_ATTEMPTS = 12')
+    && readbackSource.includes('maxBuffer: 64 * 1024') && readbackSource.includes('npmReadbackObservation'))
 assertContract('GitHub prerelease is created from the workflow SHA',
   /gh release create[\s\S]*?--prerelease[\s\S]*?--target "\$GITHUB_SHA"[\s\S]*?--generate-notes/.test(workflow))
 assertContract('workflow never promotes the latest dist-tag', !/npm dist-tag add/.test(workflow))
@@ -95,6 +98,23 @@ assertContract(
     !step.split('\n').some(line => /^(?:      - |        )(?:if|continue-on-error):/.test(line)),
   ),
 )
+
+const recoveryWorkflow = readFileSync(new URL('../.github/workflows/recover-release.yml', import.meta.url), 'utf8')
+const recoverySource = readFileSync(new URL('./recover-release.mjs', import.meta.url), 'utf8')
+assertContract('recovery is manual, main-only and protected by the release environment',
+  /^on:\s*\n\s+workflow_dispatch:/m.test(recoveryWorkflow)
+    && !/^\s+(?:push|pull_request|schedule):/m.test(recoveryWorkflow)
+    && recoveryWorkflow.includes("github.ref == 'refs/heads/main'")
+    && recoveryWorkflow.includes('environment: npm-release') && recoveryWorkflow.includes('group: npm-release'))
+assertContract('recovery grants no OIDC or npm credential and never republishes or promotes',
+  !/id-token|NPM_TOKEN|NODE_AUTH_TOKEN|npm publish|npm dist-tag|pnpm install/.test(recoveryWorkflow + recoverySource))
+assertContract('recovery actions are pinned and checkout credentials are not persisted',
+  [...recoveryWorkflow.matchAll(/uses:\s+([^\s#]+)/g)].every(match => /@[0-9a-f]{40}$/.test(match[1]))
+    && recoveryWorkflow.includes('persist-credentials: false'))
+assertContract('recovery uses an explicit confirmation and only the tested helper',
+  recoveryWorkflow.includes('CONFIRM: ${{ inputs.confirm }}')
+    && recoveryWorkflow.includes('run: node scripts/recover-release.mjs --version "$VERSION" --run-id "$ORIGINAL_RUN_ID" --apply')
+    && recoverySource.includes("confirmation !== 'RECOVER'"))
 
 if (failures.length > 0) {
   console.error(`release workflow contract failed (${failures.length}/${assertionCount}):`)

--- a/scripts/recover-release.mjs
+++ b/scripts/recover-release.mjs
@@ -1,0 +1,198 @@
+import { createHash } from 'node:crypto'
+import { mkdtemp, readFile, readdir, lstat, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { gunzipSync } from 'node:zlib'
+import { runBoundedCommand } from './bounded-command.mjs'
+import { assertReleaseCI } from './verify-release-ci.mjs'
+import { isAlphaReleaseVersion } from './release-metadata.mjs'
+
+export const RECOVERY_REPOSITORY = 'franksong2702/dsh-codex-connect'
+const PACKAGE = 'dsh-codex-connect'
+const SHA = /^[a-f0-9]{40}$/u
+const MAX_ARCHIVE = 8 * 1024 * 1024
+const digest = (bytes, algorithm) => createHash(algorithm).update(bytes).digest('hex')
+
+/** A failed readback is recoverable only after the original publish step really succeeded. */
+export function assertRecoveryRun(run, jobs) {
+  if (run?.repository?.full_name !== RECOVERY_REPOSITORY || run.head_repository?.full_name !== RECOVERY_REPOSITORY
+    || run.path !== '.github/workflows/release.yml' || run.head_branch !== 'main'
+    || run.event !== 'workflow_dispatch' || run.status !== 'completed' || !SHA.test(run.head_sha ?? '')
+    || !Array.isArray(jobs) || jobs.filter(job => job.name === 'verify').length !== 1
+    || jobs.filter(job => job.name === 'publish').length !== 1) throw new Error('Original release identity or jobs are not verifiable')
+  const verify = jobs.find(job => job.name === 'verify')
+  const publish = jobs.find(job => job.name === 'publish')
+  if (verify.status !== 'completed' || verify.conclusion !== 'success' || publish.status !== 'completed') throw new Error('Original release verification did not complete successfully')
+  for (const name of ['Recheck exact SHA CI after environment approval', 'Verify package digest', 'Publish alpha through npm Trusted Publishing']) {
+    const matches = publish.steps?.filter(step => step.name === name) ?? []
+    if (matches.length !== 1 || matches[0].status !== 'completed' || matches[0].conclusion !== 'success') throw new Error('Original authorized publication is not proven; do not republish')
+  }
+}
+
+export function selectRecoveryArtifact(list, run) {
+  if (list?.total_count !== list?.artifacts?.length) throw new Error('Incomplete original artifact listing')
+  const matches = list.artifacts.filter(artifact => artifact.name === `verified-package-${run.head_sha}`)
+  if (matches.length !== 1) throw new Error('Expected exactly one original verified artifact')
+  const artifact = matches[0]
+  if (artifact.expired !== false || !Number.isSafeInteger(artifact.id) || artifact.id < 1
+    || !Number.isSafeInteger(artifact.size_in_bytes) || artifact.size_in_bytes < 1 || artifact.size_in_bytes > MAX_ARCHIVE
+    || artifact.workflow_run?.id !== run.id || artifact.workflow_run?.head_sha !== run.head_sha) {
+    throw new Error('Original verified artifact is expired, oversized, or belongs to another run')
+  }
+  return artifact
+}
+
+/** Read only the bounded manifest from tar bytes; never extract or execute package files. */
+export function packedManifest(archive) {
+  if (!Buffer.isBuffer(archive) || archive.length > MAX_ARCHIVE) throw new Error('Package archive exceeds the recovery bound')
+  const tar = gunzipSync(archive, { maxOutputLength: 32 * 1024 * 1024 })
+  let manifest
+  for (let offset = 0; offset + 512 <= tar.length;) {
+    const header = tar.subarray(offset, offset + 512)
+    if (header.every(byte => byte === 0)) break
+    const text = (start, end) => header.subarray(start, end).toString('utf8').replace(/\0.*$/su, '')
+    const name = text(0, 100)
+    const prefix = text(345, 500)
+    const sizeText = text(124, 136).trim()
+    if (!/^[0-7]+$/u.test(sizeText)) throw new Error('Invalid tar entry size')
+    const size = Number.parseInt(sizeText, 8)
+    if (!Number.isSafeInteger(size) || offset + 512 + size > tar.length) throw new Error('Truncated package archive')
+    if ((prefix ? `${prefix}/${name}` : name) === 'package/package.json') {
+      if (manifest !== undefined || size > 64 * 1024 || ![0, 48].includes(header[156])) throw new Error('Ambiguous package manifest')
+      manifest = JSON.parse(tar.subarray(offset + 512, offset + 512 + size).toString('utf8'))
+    }
+    offset += 512 + Math.ceil(size / 512) * 512
+  }
+  if (manifest === undefined) throw new Error('Package manifest is missing')
+  return manifest
+}
+
+export function assertPublishedArtifact(version, metadata, originalBytes, npmBytes) {
+  const expectedUrl = `https://registry.npmjs.org/${PACKAGE}/-/${PACKAGE}-${version}.tgz`
+  if (metadata?.name !== PACKAGE || metadata.version !== version || metadata.dist?.tarball !== expectedUrl) throw new Error('npm metadata does not identify the exact published package')
+  if (digest(originalBytes, 'sha256') !== digest(npmBytes, 'sha256')) throw new Error('npm bytes differ from the original verified artifact')
+  const integrity = `sha512-${createHash('sha512').update(npmBytes).digest('base64')}`
+  if (metadata.dist.integrity !== integrity || metadata.dist.shasum !== digest(npmBytes, 'sha1')) throw new Error('npm integrity verification failed')
+  const manifest = packedManifest(npmBytes)
+  if (manifest.name !== PACKAGE || manifest.version !== version) throw new Error('Packed manifest does not match the recovery target')
+  return digest(npmBytes, 'sha256')
+}
+
+async function resolveTag(io, tag) {
+  let object = (await io.github(`git/ref/tags/${tag}`, 'GET', undefined, true))?.object
+  for (let depth = 0; object !== undefined && depth < 5; depth += 1) {
+    if (!SHA.test(object.sha ?? '')) throw new Error('Invalid tag object')
+    if (object.type === 'commit') return object.sha
+    if (object.type !== 'tag') throw new Error('Tag does not identify a commit')
+    object = (await io.github(`git/tags/${object.sha}`)).object
+  }
+  if (object !== undefined) throw new Error('Tag indirection exceeds the recovery bound')
+  return undefined
+}
+
+/** Default is read-only. Apply can only create missing refs/releases, never overwrite them. */
+export async function recoverRelease({ version, runId, apply = false, confirmation }, io = recoveryIO()) {
+  if (!isAlphaReleaseVersion(version) || !/^[1-9]\d{0,15}$/u.test(String(runId))) throw new Error('Expected an exact Alpha version and numeric original run ID')
+  if (apply && confirmation !== 'RECOVER') throw new Error('Apply requires exact RECOVER confirmation')
+  const run = await io.github(`actions/runs/${runId}`)
+  if (String(run.id) !== String(runId) || !Number.isSafeInteger(run.run_attempt) || run.run_attempt < 1) throw new Error('Original run ID or attempt mismatch')
+  const jobs = await io.github(`actions/runs/${runId}/attempts/${run.run_attempt}/jobs?per_page=100`)
+  if (jobs.total_count !== jobs.jobs?.length) throw new Error('Incomplete original job listing')
+  assertRecoveryRun(run, jobs.jobs)
+  const sha = run.head_sha
+  const ancestry = await io.github(`compare/${sha}...main`)
+  if (!['ahead', 'identical'].includes(ancestry.status)) throw new Error('Original release SHA is not on main')
+  const ci = (await io.github(`actions/workflows/ci.yml/runs?head_sha=${sha}&branch=main&per_page=100`)).workflow_runs?.[0]
+  if (!ci) throw new Error('Original main CI is missing')
+  const ciJobs = await io.github(`actions/runs/${ci.id}/attempts/${ci.run_attempt}/jobs?per_page=100`)
+  if (ciJobs.total_count !== ciJobs.jobs?.length) throw new Error('Incomplete original CI job listing')
+  assertReleaseCI(ci, ciJobs.jobs, sha, RECOVERY_REPOSITORY)
+  const artifact = selectRecoveryArtifact(await io.github(`actions/runs/${runId}/artifacts?per_page=100`), run)
+  const originalBytes = await io.artifact(runId, artifact.name)
+  const metadata = await io.npmMetadata(version)
+  const expectedUrl = `https://registry.npmjs.org/${PACKAGE}/-/${PACKAGE}-${version}.tgz`
+  if (metadata.dist?.tarball !== expectedUrl) throw new Error('Unexpected npm tarball origin or path')
+  const sha256 = assertPublishedArtifact(version, metadata, originalBytes, await io.tarball(expectedUrl))
+  const tag = `v${version}`
+  const tagSha = await resolveTag(io, tag)
+  if (tagSha !== undefined && tagSha !== sha) throw new Error('Existing tag points elsewhere; refusing to move it')
+  const release = await io.github(`releases/tags/${tag}`, 'GET', undefined, true)
+  const result = { version, runId: String(runId), sha, sha256, npmRepublished: false, tagsPromoted: false }
+  if (release) {
+    if (tagSha !== sha || release.tag_name !== tag || release.draft !== false || release.prerelease !== true) throw new Error('Existing release conflicts with the recovery target')
+    return { status: 'already-complete', ...result, releaseId: release.id }
+  }
+  if (!apply) return { status: 'verified-recovery-needed', ...result }
+  if (tagSha === undefined) await io.github('git/refs', 'POST', { ref: `refs/tags/${tag}`, sha })
+  if (await resolveTag(io, tag) !== sha) throw new Error('Tag changed before release creation')
+  await io.github('releases', 'POST', { tag_name: tag, target_commitish: sha, name: tag, prerelease: true, draft: false, generate_release_notes: true, make_latest: 'false' })
+  const created = await io.github(`releases/tags/${tag}`)
+  if (await resolveTag(io, tag) !== sha || created.tag_name !== tag || created.draft !== false || created.prerelease !== true) throw new Error('Release creation readback mismatch; inspect before retrying')
+  return { status: 'recovered', ...result, releaseId: created.id }
+}
+
+async function fetchBytes(url, maxBytes) {
+  const response = await fetch(url, { redirect: 'error', cache: 'no-store', signal: AbortSignal.timeout(30_000) })
+  if (!response.ok) throw new Error(`npm registry request failed with HTTP ${response.status}`)
+  let size = 0
+  const chunks = []
+  for await (const chunk of response.body) {
+    size += chunk.length
+    if (size > maxBytes) throw new Error('npm response exceeds the recovery bound')
+    chunks.push(chunk)
+  }
+  return Buffer.concat(chunks)
+}
+
+function recoveryIO() {
+  const command = async args => {
+    const result = await runBoundedCommand('gh', args, { timeoutMs: 60_000, maxBuffer: 2 * 1024 * 1024 })
+    if (result.error || result.cleanupError) throw new Error('Bounded GitHub command failed')
+    return result
+  }
+  return {
+    async github(path, method = 'GET', payload, allowMissing = false) {
+      const args = ['api', '--include', '--method', method, `repos/${RECOVERY_REPOSITORY}/${path}`]
+      for (const [key, value] of Object.entries(payload ?? {})) args.push(typeof value === 'boolean' ? '--field' : '--raw-field', `${key}=${value}`)
+      const result = await command(args)
+      const status = Number(result.stdout.match(/^HTTP\/\S+ (\d{3})/mu)?.[1])
+      if (allowMissing && status === 404) return undefined
+      if (result.status !== 0 || status < 200 || status >= 300 || !Number.isFinite(status)) throw new Error(`GitHub API request failed with status ${Number.isFinite(status) ? status : 'unknown'}`)
+      const split = result.stdout.search(/\r?\n\r?\n/u)
+      if (split < 0) throw new Error('GitHub API response has no JSON body')
+      return JSON.parse(result.stdout.slice(split).trim())
+    },
+    async artifact(runId, name) {
+      const root = await mkdtemp(join(tmpdir(), 'codex-connect-release-recovery-'))
+      try {
+        const result = await command(['run', 'download', String(runId), '--repo', RECOVERY_REPOSITORY, '--name', name, '--dir', root])
+        if (result.status !== 0) throw new Error('Original verified artifact download failed; no recovery was attempted')
+        const entries = await readdir(root)
+        const path = join(root, 'release.tgz')
+        const stat = await lstat(path)
+        if (entries.length !== 1 || entries[0] !== 'release.tgz' || !stat.isFile() || stat.size > MAX_ARCHIVE) throw new Error('Unexpected verified artifact contents')
+        return await readFile(path)
+      } finally { await rm(root, { recursive: true, force: true }) }
+    },
+    async npmMetadata(version) { return JSON.parse((await fetchBytes(`https://registry.npmjs.org/${PACKAGE}/${version}`, 512 * 1024)).toString('utf8')) },
+    async tarball(url) { return fetchBytes(url, MAX_ARCHIVE) },
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const args = process.argv.slice(2)
+    const apply = args.at(-1) === '--apply'
+    if (apply) args.pop()
+    if (args.length !== 4 || args[0] !== '--version' || args[2] !== '--run-id') throw new Error('Usage: recover-release --version <alpha> --run-id <original-id> [--apply]')
+    if (process.env.GITHUB_ACTIONS === 'true' && (process.env.GITHUB_REF !== 'refs/heads/main' || process.env.GITHUB_REPOSITORY !== RECOVERY_REPOSITORY)) throw new Error('Recovery workflow must run on the repository main branch')
+    const result = await recoverRelease({ version: args[1], runId: args[3], apply, confirmation: process.env.CONFIRM })
+    console.log(JSON.stringify(result))
+  } catch (error) {
+    // Do not emit captured remote bodies, credential-bearing URLs, or filesystem paths.
+    const message = error instanceof SyntaxError ? 'Invalid structured recovery response' : error instanceof Error ? error.message : 'Recovery failed'
+    console.error(/https?:|[/\\\\]|Bearer\s/iu.test(message) ? 'Recovery failed while reading external evidence; raw diagnostics withheld' : message.slice(0, 240))
+    process.exitCode = 1
+  }
+}

--- a/scripts/recover-release.test.mjs
+++ b/scripts/recover-release.test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
+import { gzipSync } from 'node:zlib'
+import { assertRecoveryRun, packedManifest, recoverRelease, RECOVERY_REPOSITORY } from './recover-release.mjs'
+
+const version = '0.1.0-alpha.4.34'
+const sha = 'a'.repeat(40)
+const packageName = 'dsh-codex-connect'
+const manifest = Buffer.from(JSON.stringify({ name: packageName, version }))
+const header = Buffer.alloc(512)
+header.write('package/package.json')
+header.write(manifest.length.toString(8).padStart(11, '0') + '\0', 124)
+header[156] = 48
+const tar = Buffer.concat([header, manifest, Buffer.alloc((512 - manifest.length % 512) % 512), Buffer.alloc(1024)])
+const archive = gzipSync(tar)
+assert.deepEqual(packedManifest(archive), { name: packageName, version })
+assert.throws(() => packedManifest(gzipSync(Buffer.alloc(1024))), /missing/)
+const npm = {
+  name: packageName, version,
+  dist: {
+    tarball: `https://registry.npmjs.org/${packageName}/-/${packageName}-${version}.tgz`,
+    integrity: `sha512-${createHash('sha512').update(archive).digest('base64')}`,
+    shasum: createHash('sha1').update(archive).digest('hex'),
+  },
+}
+const original = {
+  id: 123, run_attempt: 1, head_sha: sha, head_branch: 'main',
+  repository: { full_name: RECOVERY_REPOSITORY }, head_repository: { full_name: RECOVERY_REPOSITORY },
+  path: '.github/workflows/release.yml', event: 'workflow_dispatch', status: 'completed', conclusion: 'failure',
+}
+const jobs = [
+  { name: 'verify', status: 'completed', conclusion: 'success' },
+  { name: 'publish', status: 'completed', conclusion: 'failure', steps: ['Recheck exact SHA CI after environment approval', 'Verify package digest', 'Publish alpha through npm Trusted Publishing'].map(name => ({ name, status: 'completed', conclusion: 'success' })) },
+]
+assert.doesNotThrow(() => assertRecoveryRun(original, jobs))
+for (const change of [{ event: 'pull_request' }, { head_branch: 'other' }, { status: 'in_progress' }, { head_sha: 'invalid' }, { head_repository: { full_name: 'other/repo' } }]) {
+  assert.throws(() => assertRecoveryRun({ ...original, ...change }, jobs))
+}
+const failedPublish = structuredClone(jobs)
+failedPublish[1].steps[2].conclusion = 'failure'
+assert.throws(() => assertRecoveryRun(original, failedPublish), /not proven/)
+
+function fixture(options = {}) {
+  const state = { tagSha: options.tagSha, release: options.release, writes: [] }
+  const ci = { ...original, id: 321, path: '.github/workflows/ci.yml', event: 'push', conclusion: 'success' }
+  const ciJobs = ['validate (22.19.0)', 'validate (24.x)', 'browser-ui-regression', 'windows-canary-contract'].map(name => ({ name, status: 'completed', conclusion: 'success' }))
+  const artifact = { id: 42, name: `verified-package-${sha}`, size_in_bytes: archive.length, expired: false, workflow_run: { id: 123, head_sha: sha }, ...options.artifact }
+  return { state, io: {
+    async github(path, method = 'GET', payload) {
+      if (method === 'POST') {
+        state.writes.push({ path, payload })
+        if (path === 'git/refs') state.tagSha = payload.sha
+        else if (path === 'releases') state.release = { id: 456, tag_name: payload.tag_name, draft: false, prerelease: true }
+        else throw new Error('Unexpected write')
+        return {}
+      }
+      if (path === 'actions/runs/123') return { ...original, ...options.run }
+      if (path === 'actions/runs/123/attempts/1/jobs?per_page=100') return { total_count: jobs.length, jobs: options.jobs ?? jobs }
+      if (path === `compare/${sha}...main`) return { status: options.ancestry ?? 'ahead' }
+      if (path.startsWith('actions/workflows/ci.yml/runs?')) return { workflow_runs: [ci] }
+      if (path === 'actions/runs/321/attempts/1/jobs?per_page=100') return { total_count: ciJobs.length, jobs: options.ciJobs ?? ciJobs }
+      if (path === 'actions/runs/123/artifacts?per_page=100') return { total_count: 1, artifacts: [artifact] }
+      if (path === `git/ref/tags/v${version}`) return state.tagSha ? { object: { type: 'commit', sha: state.tagSha } } : undefined
+      if (path === `releases/tags/v${version}`) return state.release
+      throw new Error('Unexpected fixture API path')
+    },
+    async artifact() { return options.originalBytes ?? archive },
+    async npmMetadata() { return options.npm ?? npm },
+    async tarball() { return archive },
+  } }
+}
+const dry = fixture()
+assert.equal((await recoverRelease({ version, runId: 123 }, dry.io)).status, 'verified-recovery-needed')
+assert.equal(dry.state.writes.length, 0)
+const apply = fixture()
+assert.equal((await recoverRelease({ version, runId: 123, apply: true, confirmation: 'RECOVER' }, apply.io)).status, 'recovered')
+assert.deepEqual(apply.state.writes.map(write => write.path), ['git/refs', 'releases'])
+assert.equal((await recoverRelease({ version, runId: 123, apply: true, confirmation: 'RECOVER' }, apply.io)).status, 'already-complete')
+assert.equal(apply.state.writes.length, 2)
+for (const options of [
+  { tagSha: 'b'.repeat(40) }, { artifact: { expired: true } }, { artifact: { workflow_run: { id: 999, head_sha: sha } } },
+  { originalBytes: Buffer.from('different bytes') }, { npm: { ...npm, dist: { ...npm.dist, integrity: 'invalid' } } },
+  { npm: { ...npm, dist: { ...npm.dist, tarball: 'https://untrusted.invalid/package.tgz' } } },
+  { ancestry: 'diverged' }, { jobs: failedPublish }, { ciJobs: [] },
+  { tagSha: sha, release: { tag_name: `v${version}`, draft: true, prerelease: true } },
+]) {
+  const invalid = fixture(options)
+  await assert.rejects(() => recoverRelease({ version, runId: 123, apply: true, confirmation: 'RECOVER' }, invalid.io))
+  assert.equal(invalid.state.writes.length, 0)
+}
+await assert.rejects(() => recoverRelease({ version, runId: 123, apply: true }, fixture().io), /RECOVER/)
+await assert.rejects(() => recoverRelease({ version: 'latest', runId: 123 }, fixture().io), /exact Alpha/)
+await assert.rejects(() => recoverRelease({ version, runId: '../123' }, fixture().io), /numeric original/)
+console.log('release recovery regressions: provenance, exact CI, integrity, expiry, conflicts, read-only default, confirmation, and idempotence passed')

--- a/scripts/verify-npm-readback.mjs
+++ b/scripts/verify-npm-readback.mjs
@@ -1,0 +1,65 @@
+import { pathToFileURL } from 'node:url'
+import { setTimeout as delay } from 'node:timers/promises'
+import { runBoundedCommand } from './bounded-command.mjs'
+import { isAlphaReleaseVersion } from './release-metadata.mjs'
+
+export const RELEASE_PACKAGE = 'dsh-codex-connect'
+export const NPM_READBACK_ATTEMPTS = 12
+const SAFE_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u
+const SAFE_ERROR_CODES = new Set(['E401', 'E403', 'E404', 'E429', 'E500', 'E502', 'E503', 'EAI_AGAIN', 'ECONNRESET', 'ENOTFOUND', 'ETIMEDOUT', 'ENOBUFS', 'ENOENT'])
+const safeVersion = value => typeof value === 'string' && value.length <= 128 && SAFE_VERSION.test(value) ? value : null
+
+/** Return only allowlisted diagnostics, never raw npm bodies, paths, or auth material. */
+export function npmReadbackObservation(result, field) {
+  let parsed
+  try { parsed = JSON.parse(result.stdout ?? '') } catch {}
+  const code = result.error?.code ?? parsed?.error?.code
+  const errorCode = SAFE_ERROR_CODES.has(code) ? code : null
+  const exitCode = Number.isInteger(result.status) ? result.status : null
+  if (result.error || result.cleanupError || exitCode !== 0) {
+    return { status: 'query-failed', exitCode, errorCode, value: null }
+  }
+  if (field === 'version') {
+    const value = safeVersion(parsed)
+    return { status: value === null ? 'invalid-response' : 'observed', exitCode, errorCode, value }
+  }
+  const value = { alpha: safeVersion(parsed?.alpha), latest: safeVersion(parsed?.latest) }
+  return { status: value.alpha === null ? 'invalid-response' : 'observed', exitCode, errorCode, value }
+}
+
+/** Bound both npm's internal fetch and the whole child process; prefer fresh registry metadata. */
+export async function verifyNpmReadback(version, dependencies = {}) {
+  if (!isAlphaReleaseVersion(version)) throw new Error('Expected one exact numeric Alpha version')
+  const run = dependencies.run ?? runBoundedCommand
+  const sleep = dependencies.sleep ?? delay
+  const log = dependencies.log ?? (value => console.log(JSON.stringify(value)))
+  const attempts = dependencies.attempts ?? NPM_READBACK_ATTEMPTS
+  if (!Number.isInteger(attempts) || attempts < 1 || attempts > NPM_READBACK_ATTEMPTS) throw new Error('Invalid readback attempt budget')
+  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+  const flags = ['--json', '--prefer-online', '--registry=https://registry.npmjs.org/', '--fetch-retries=0', '--fetch-timeout=12000']
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const [versionResult, tagsResult] = await Promise.all([
+      run(npm, ['view', `${RELEASE_PACKAGE}@${version}`, 'version', ...flags], { timeoutMs: 20_000, maxBuffer: 64 * 1024 }),
+      run(npm, ['view', RELEASE_PACKAGE, 'dist-tags', ...flags], { timeoutMs: 20_000, maxBuffer: 64 * 1024 }),
+    ])
+    const published = npmReadbackObservation(versionResult, 'version')
+    const tags = npmReadbackObservation(tagsResult, 'tags')
+    const matches = published.status === 'observed' && tags.status === 'observed'
+      && published.value === version && tags.value.alpha === version
+    log({ step: 'npm-readback', attempt, expected: version, published, tags, matches })
+    if (matches) return { version, alpha: tags.value.alpha, latest: tags.value.latest, attempts: attempt }
+    if (attempt < attempts) await sleep(10_000)
+  }
+  throw new Error('npm readback did not confirm the exact version and alpha tag. Inspect the safe observations; do not rerun publication. Use recovery-only verification after registry availability is confirmed.')
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    if (process.argv.length > 3) throw new Error('Usage: verify-npm-readback [version]')
+    const result = await verifyNpmReadback(process.argv[2] ?? process.env.VERSION)
+    console.log(JSON.stringify({ status: 'verified', ...result }))
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : 'npm readback failed')
+    process.exitCode = 1
+  }
+}

--- a/scripts/verify-npm-readback.test.mjs
+++ b/scripts/verify-npm-readback.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import { npmReadbackObservation, verifyNpmReadback } from './verify-npm-readback.mjs'
+
+const version = '0.1.0-alpha.4.34'
+const good = value => ({ status: 0, stdout: JSON.stringify(value), stderr: '' })
+assert.equal(npmReadbackObservation(good(version), 'version').value, version)
+assert.equal(npmReadbackObservation({ status: 0, stdout: 'not-json' }, 'version').status, 'invalid-response')
+assert.equal(npmReadbackObservation({ ...good(version), status: 1 }, 'version').status, 'query-failed')
+assert.equal(npmReadbackObservation({ ...good(version), error: { code: 'ETIMEDOUT' } }, 'version').errorCode, 'ETIMEDOUT')
+assert.equal(npmReadbackObservation(good({ latest: version }), 'tags').status, 'invalid-response')
+const secret = 'private-fixture-value'
+const redacted = JSON.stringify(npmReadbackObservation({ status: 1, stdout: JSON.stringify({ error: { code: 'E404', summary: secret } }), stderr: secret }, 'version'))
+assert.ok(!redacted.includes(secret))
+assert.ok(redacted.includes('E404'))
+assert.ok(!JSON.stringify(npmReadbackObservation(good({ alpha: secret, latest: secret }), 'tags')).includes(secret))
+
+let calls = 0
+let sleeps = 0
+const logs = []
+const result = await verifyNpmReadback(version, {
+  attempts: 3,
+  run: async (_command, args, options) => {
+    calls += 1
+    assert.ok(args.includes('--prefer-online'))
+    assert.ok(args.includes('--registry=https://registry.npmjs.org/'))
+    assert.equal(options.timeoutMs, 20_000)
+    if (calls <= 2) return args[2] === 'version' ? good(version) : good({ alpha: '0.1.0-alpha.4.33', latest: '0.1.0-alpha.4.30' })
+    return args[2] === 'version' ? good(version) : good({ alpha: version, latest: '0.1.0-alpha.4.30' })
+  },
+  sleep: async ms => { assert.equal(ms, 10_000); sleeps += 1 },
+  log: value => logs.push(value),
+})
+assert.equal(result.attempts, 2)
+assert.equal(calls, 4)
+assert.equal(sleeps, 1)
+assert.equal(logs[0].matches, false)
+assert.equal(logs[1].matches, true)
+for (const response of [good('0.1.0-alpha.4.33'), { status: 1, stdout: secret, stderr: secret }, { status: 0, stdout: '{}' }]) {
+  await assert.rejects(() => verifyNpmReadback(version, { attempts: 1, run: async () => response, log: () => {} }), /do not rerun publication/)
+}
+await assert.rejects(() => verifyNpmReadback('invalid', { run: async () => { throw new Error('must not execute') } }), /exact numeric Alpha/)
+console.log('npm readback regressions: mismatch, recovery, bounded retries, failures, and diagnostic privacy passed')


### PR DESCRIPTION
## Summary

Replace silent post-publish npm polling with tested, bounded `--prefer-online` registry reads. Structured diagnostics retain only exit codes, allowlisted error codes, valid versions/tags, and match status. A readback failure is not assumed to be propagation delay.

Add an independent manual recovery-only workflow under the existing npm-release environment and concurrency lock, with no OIDC/npm publication permissions or dependency installation. Default CLI execution is read-only. Confirmed recovery verifies original repository/main/release run, successful verify and authorized publish steps, exact-SHA CI, a non-expired original artifact, npm archive byte identity plus SHA-512/SHA-1 and manifest, and tag/release identity before creating only missing GitHub records. It never moves tags, promotes channels, or republishes. Matching existing releases are no-ops; evidence gaps and conflicts fail closed. Update RELEASING.md accordingly.

## Validation

- Frozen dependencies unchanged; full `pnpm run check` passed, including new decision regressions and 39 release workflow assertions.
- Tested stale readback then recovery, malformed/failing responses, diagnostic privacy, time budgets, source-run/CI mismatch, expired/wrong artifacts, byte/integrity mismatch, foreign tarball URLs, conflicting tags/releases, read-only default, explicit confirmation and idempotence.
- Real online readback confirmed published 4.34, alpha=4.34, latest=4.34.
- Real read-only recovery against original run 34552519354 returned already-complete for original SHA d3ab2fbc8b297feeb4930a33e75b5b7aace14d8a and archive SHA-256 d9ac135f1a77b9b8e882c25b145624597c1213d6dcde970630818cbd2c405f65. No mutations occurred.
- Rebased onto merged canary PR #190; complete tree remains byte-identical to the locally tested tree. `git diff --check` passed.

No runtime source, built library, dependencies, version, declared compatibility set, npm release/tag, existing user services or credentials changed. This does not claim live model or full GUI acceptance.